### PR TITLE
fix(memory-propose-confirm): treat unanswered propose as deferred, no…

### DIFF
--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -40,7 +40,7 @@ agent 收到指引時，skill 內容會 on-demand 被拉進來，訊號明確（
 | [`github-title-description`](../skills/github-title-description.md) | Tomori | `/maigo:describe-pr` step 2 | 從 branch commits / diff 產 user-impact PR title + Why / What / Test Plan |
 | [`pr-context-cache`](../skills/pr-context-cache.md) | Raana | `/maigo:review` step 1 | 把 PR title/body/diff/CI status/linked issues cache 到 review-rubric.md，re-review 時跳過重抓 |
 | [`memory-loading`](../skills/memory-loading.md) | Raana / Tomori / Soyo | 全部 agent 啟動時 | 跨專案記憶載入 5 步流程、schema 自檢、fallback 規則、10 筆上限 |
-| [`memory-propose-confirm`](../skills/memory-propose-confirm.md) | orchestrator | `/maigo:go`、`/maigo:quick`、`/maigo:team` | Memory propose 的 6 步 confirm flow、fence-tracking 規則、並行模式追加 |
+| [`memory-propose-confirm`](../skills/memory-propose-confirm.md) | orchestrator | `/maigo:go`、`/maigo:quick`、`/maigo:team`、`/maigo:review` | Memory propose 的 confirm flow、存 / 跳過 / 未決三態（no-answer ≠ 跳過）、fence-tracking 規則、並行模式追加 |
 | [`narration`](../skills/narration.md) | orchestrator | 全部 `/maigo:*` 命令 | maigo orchestrator 的旁白——🌙 Doloris / 🌑 Mortis 在開場 / 收場 / 卡關節點框住整場演出 |
 | [`teammate-flow`](../skills/teammate-flow.md) | orchestrator | `/maigo:go`、`/maigo:team` | MyGO!!!!! 五人協作的共通流程骨架——sequential 段（🐱 樂奈 → 🩵 燈 → 🎀 愛音）、Orchestrator 守則、commit message draft 規則、失敗處理與 memory confirm flow 引用 |
 | [`doc-link-convention`](../skills/doc-link-convention.md) | Soyo | review 觸及 `agents/` / `commands/` / `skills/` 的 PR 時 | Maigo source 檔的跨檔 link 強制用絕對 GitHub URL，避免 `mkdocs build --strict` 因 include-markdown rewrite 抓不到 page 而 abort |

--- a/hooks/verify_completion.py
+++ b/hooks/verify_completion.py
@@ -62,6 +62,30 @@ BUILD_ENV_ERROR_RE = re.compile(
     r"|(?:gcc|cc|clang|cl): command not found"
     r"|No such file or directory: ['\"]?(?:gcc|cc|clang|make|cmake)['\"]?",
 )
+# pytest collection / usage / config errors and "no tests ran" mean the suite
+# never executed — the project's own code didn't fail, the *invocation* did.
+# The classic case is a uv-workspace monorepo whose root needs `--project`:
+# bare `uv run pytest` then errors out in a sub-package conftest
+# (`pytest-plugins-in-non-top-level-conftest-files`). These emit no FAILED
+# lines, so without this guard they fall through to the blind block below and
+# loop forever (no test name to act on). Import/syntax errors in the user's
+# own changed code are caught earlier by FATAL_MARKER_RE and still block; this
+# pattern is for setup/invocation problems the operator fixes via
+# `.claude/test-command`, not for masking real test breakage.
+COLLECTION_ERROR_RE = re.compile(
+    r"non-top-level[ -]conftest"  # pytest-plugins-in-non-top-level-conftest(-files)
+    r"|errors during collection"
+    r"|ERROR collecting "
+    r"|no tests ran in"
+    r"|ERROR: file or directory not found"
+    r"|ERROR: not found:"
+    r"|unrecognized arguments"
+    # pytest summary reporting *errors* (collection) rather than failures, e.g.
+    # "1 error in 0.30s" / "2 errors in 1.1s". Only consulted when no FAILED
+    # line was parseable (see call site), so it cannot mask real failures that
+    # happen to share a summary line with errors.
+    r"|\b\d+ errors? in [\d.]+s",
+)
 
 
 def has_git_modifications(cwd: Path) -> bool:
@@ -260,7 +284,34 @@ def main() -> None:
             f"立希 (Taki)：{len(actual)} 個失敗全在 known-test-failures 名單，放行",
         )
 
+    # No parseable failures at this point. If the output looks like a
+    # collection / usage / config error (the suite never ran — e.g. a
+    # uv-workspace monorepo root that needs `--project`), treat it like
+    # build-env: skip with guidance. Checked here (not before extract_failures)
+    # so a summary that mixes errors *and* real failures still blocks on the
+    # failures above. Import/syntax errors in the user's own code are caught
+    # earlier by FATAL_MARKER_RE and still block.
+    collection_match = COLLECTION_ERROR_RE.search(output)
+    if collection_match:
+        emit(
+            "approve",
+            f"立希 (Taki)：`{' '.join(cmd)}` 失敗於 test collection / 設定（{collection_match.group(0)!r}），suite 根本沒跑——不是 test 失敗。常見於 uv-workspace monorepo 根目錄要用 `--project`。跳過——在 `.claude/test-command` 改成可跑的指令（例如 `uv run --project <pkg> pytest <path>`），或 `.claude/skip-test-verification` 寫一行 reason 永久關閉本 worktree 的檢查。",
+        )
+
+    # Non-zero exit we couldn't attribute to any test name (and not a
+    # recognized build-env / collection / config error). Block so the operator
+    # sees it — but route through the retry log so a genuinely unparseable
+    # command can't loop forever: after RETRY_LIMIT consecutive such blocks,
+    # approve with a warning to get human intervention. The key is stable per
+    # command so distinct commands count independently.
     tail = output[-OUTPUT_TAIL_CHARS:] if len(output) > OUTPUT_TAIL_CHARS else output
+    unparsed_key = f"__unparsed_nonzero__:{' '.join(cmd)}"
+    counts = _record_and_count(_retry_log_path(cwd), {unparsed_key})
+    if counts.get(unparsed_key, 0) >= RETRY_LIMIT:
+        emit(
+            "approve",
+            f"⚠️ RETRY LIMIT REACHED: 立希 (Taki)：`{' '.join(cmd)}` exit {exit_code} 已連續 ≥ {RETRY_LIMIT} 次無法 parse failure（本次含），停止重試以免無限迴圈，放行——請人工介入確認。依 skills/failure-handling 的「無限迴圈防護」。若這是 collection / 設定問題，在 `.claude/test-command` 改成可跑的指令，或 `.claude/skip-test-verification` 寫一行 reason 關閉本 worktree 的檢查。Raw tail:\n{tail}",
+        )
     emit(
         "block",
         f"立希 (Taki)：`{' '.join(cmd)}` exit {exit_code}，無法 parse failure 名稱。Raw tail:\n{tail}",

--- a/skills/memory-propose-confirm/SKILL.md
+++ b/skills/memory-propose-confirm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-propose-confirm
-description: This skill should be used by the maigo orchestrator whenever a Soyo or Anon output contains a ## Memory propose section. Handles the 6-step confirm flow, fence-tracking rules for detecting the section, and parallel-mode timing adjustments. Applies to /maigo:go, /maigo:quick, /maigo:team.
+description: This skill should be used by the maigo orchestrator whenever a Soyo or Anon output contains a ## Memory propose section. Handles the confirm flow, fence-tracking rules for detecting the section, no-answer handling, and parallel-mode timing adjustments. Applies to /maigo:go, /maigo:quick, /maigo:team, /maigo:review.
 ---
 
 <!-- mkdocs-include-start -->
@@ -8,13 +8,13 @@ description: This skill should be used by the maigo orchestrator whenever a Soyo
 # Memory Propose Confirm Flow
 
 **Owner**: orchestrator
-**Consumers**: [`/maigo:go`](https://github.com/Lee-W/maigo/blob/main/commands/go.md)、[`/maigo:quick`](https://github.com/Lee-W/maigo/blob/main/commands/quick.md)、[`/maigo:team`](https://github.com/Lee-W/maigo/blob/main/commands/team.md)
+**Consumers**: [`/maigo:go`](https://github.com/Lee-W/maigo/blob/main/commands/go.md)、[`/maigo:quick`](https://github.com/Lee-W/maigo/blob/main/commands/quick.md)、[`/maigo:team`](https://github.com/Lee-W/maigo/blob/main/commands/team.md)、[`/maigo:review`](https://github.com/Lee-W/maigo/blob/main/commands/review.md)
 
 ## 觸發條件
 
 當 🟡 Soyo 或 🎀 Anon 的輸出末尾含 `## Memory propose` 段時，orchestrator 在該 agent 完成後、繼續下一步前，立刻執行 confirm flow。
 
-## 6 步 Confirm Flow
+## Confirm Flow
 
 1. **格式檢查**：檢查 propose 段的 6 個必填欄位（`name` / `slug` / `description` / `body` / `type` / `rationale`）是否齊全。
    缺任一欄位 → 不 confirm，印一行提示「偵測到 propose 段但格式不完整，已跳過」，繼續正常流程。
@@ -28,6 +28,27 @@ description: This skill should be used by the maigo orchestrator whenever a Soyo
 6. 選「跳過」→ 繼續正常流程，不寫任何檔。
 
 Confirm flow 完成後繼續主線流程——不改變命令的步驟結構。
+
+## 三態：存 / 跳過 / 未決（重要）
+
+confirm flow 的結果有**三**種，不是兩種。orchestrator 不可把後兩者混為一談：
+
+| 結果 | 觸發 | 處置 |
+|---|---|---|
+| **存** | 使用者選「存」/「修改」 | 寫檔（step 5） |
+| **跳過** | 使用者**明確選**「跳過」 | 不寫檔，丟棄 propose，繼續 |
+| **未決** | 使用者**沒選任何項**（關掉問題 / dismiss / AskUserQuestion 回 "did not answer"） | 不寫檔，但**不丟棄** propose |
+
+**「沒回答」≠「跳過」。** dismiss 一個問題不是 decline——它只代表「現在不決定」。把 no-answer 當成跳過會把使用者還想留著的 memory 默默吃掉。
+
+未決時 orchestrator 必須：
+
+- 不寫任何檔（跟跳過一樣）
+- **保留** propose 段——在回覆末尾原樣附上那個 `## Memory propose`（fenced，可複製），讓使用者之後說一聲就能存
+- 印一行中性提示，例如：「memory propose 未決——你沒選，我先保留著，要存再跟我說。」
+- **不要**自行推論成跳過或存，也不要追問逼使用者立刻決定；保留著、繼續主線即可
+
+使用者之後任何時點說「存那個 memory」/「剛剛那條記起來」→ 直接 reuse step 5 寫檔，不必重跑整個 confirm flow。
 
 ## Fence-Tracking 規則
 

--- a/tests/test_verify_completion.py
+++ b/tests/test_verify_completion.py
@@ -381,3 +381,140 @@ class TestMainRetryWarning:
         assert result["decision"] == "block"
         assert "⚠️ RETRY LIMIT REACHED:" in result["reason"]
         assert "2 次" in result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# main() collection / config error handling
+# ---------------------------------------------------------------------------
+
+
+class TestMainCollectionError:
+    """A test command that errors during collection / config (suite never ran)
+    must be treated as a skip, not a blocking test failure — otherwise a
+    uv-workspace monorepo root (bare `uv run pytest` needs `--project`) loops
+    forever with no parseable failure name.
+    """
+
+    CONFTEST_ERROR = (
+        "Defining 'pytest_plugins' in a non-top-level conftest is no longer "
+        "supported\n1 error in 0.30s\n"
+    )
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            CONFTEST_ERROR,
+            "no tests ran in 0.01s",
+            "ERROR: file or directory not found: nope/",
+            "ERROR: not found: tests/x.py::test_missing",
+            "pytest: error: unrecognized arguments: --bogus",
+        ],
+    )
+    def test_collection_error_approves_with_guidance(
+        self,
+        output: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ):
+        (tmp_path / "uv.lock").touch()
+        monkeypatch.setattr(
+            verify_completion, "run_command", lambda cmd, cwd: (1, output)
+        )
+        monkeypatch.setattr(
+            verify_completion, "has_git_modifications", lambda cwd: True
+        )
+        monkeypatch.setattr(
+            verify_completion, "_RETRY_LOG_BASE", tmp_path / "retry-log"
+        )
+        payload = {"cwd": str(tmp_path)}
+        result = run_hook_main(verify_completion, payload, monkeypatch, capsys)
+        assert result["decision"] == "approve"
+        assert "collection" in result["reason"]
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            "FAILED tests/x.py::test_y\n1 failed in 0.10s",
+            # Mixed: a real failure AND collection errors in the same summary —
+            # the failure must win (collection guard runs only when nothing was
+            # parseable), so this must still block.
+            "FAILED tests/x.py::test_y\n1 failed, 2 errors in 1.1s",
+        ],
+    )
+    def test_real_test_failure_still_blocks(
+        self,
+        output: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ):
+        # A genuine FAILED line must not be swallowed by the collection guard.
+        (tmp_path / "uv.lock").touch()
+        monkeypatch.setattr(
+            verify_completion,
+            "run_command",
+            lambda cmd, cwd: (1, output),
+        )
+        monkeypatch.setattr(
+            verify_completion, "has_git_modifications", lambda cwd: True
+        )
+        monkeypatch.setattr(
+            verify_completion, "_RETRY_LOG_BASE", tmp_path / "retry-log"
+        )
+        payload = {"cwd": str(tmp_path)}
+        result = run_hook_main(verify_completion, payload, monkeypatch, capsys)
+        assert result["decision"] == "block"
+
+
+# ---------------------------------------------------------------------------
+# main() unparseable non-zero exit circuit-breaker
+# ---------------------------------------------------------------------------
+
+
+class TestMainUnparsedNonZero:
+    """A non-zero exit with no parseable failures and no recognized error class
+    blocks the first times, but must approve after RETRY_LIMIT so it cannot
+    loop forever.
+    """
+
+    OPAQUE_FAILURE = "something went wrong but no test name here\nexit\n"
+
+    def _setup(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        (tmp_path / "uv.lock").touch()
+        monkeypatch.setattr(
+            verify_completion,
+            "run_command",
+            lambda cmd, cwd: (1, self.OPAQUE_FAILURE),
+        )
+        monkeypatch.setattr(
+            verify_completion, "has_git_modifications", lambda cwd: True
+        )
+        monkeypatch.setattr(
+            verify_completion, "_RETRY_LOG_BASE", tmp_path / "retry-log"
+        )
+
+    def test_first_unparsed_blocks(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ):
+        self._setup(tmp_path, monkeypatch)
+        payload = {"cwd": str(tmp_path)}
+        result = run_hook_main(verify_completion, payload, monkeypatch, capsys)
+        assert result["decision"] == "block"
+        assert "無法 parse failure" in result["reason"]
+
+    def test_repeated_unparsed_breaks_out(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ):
+        self._setup(tmp_path, monkeypatch)
+        payload = {"cwd": str(tmp_path)}
+        run_hook_main(verify_completion, payload, monkeypatch, capsys)
+        result = run_hook_main(verify_completion, payload, monkeypatch, capsys)
+        assert result["decision"] == "approve"
+        assert "⚠️ RETRY LIMIT REACHED:" in result["reason"]


### PR DESCRIPTION
…t skipped

A dismissed AskUserQuestion (no selection) was conflated with an explicit
"跳過", silently discarding a memory the user may still want. Define a third
outcome — 未決 — that writes nothing but keeps the propose section so the user
can save it later. Also add /maigo:review to the skill's consumer list, which
triggers the confirm flow but was missing.