### PR TITLE
fix(validate): keep contributor checks in sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # maigo contributor instructions for Codex agents
 
+> **鏡射檔同步**：`CLAUDE.md` 與 `AGENTS.md` 共用下列 contributor conventions。
+> 修改共同規則時必須同步另一份；平台特定措辭、連結格式與 hook runtime 說明可保留差異，
+> 否則另一端會照舊快照做事。
+
 ## Tone
 
 This project is emoji-friendly. When working in this repository
@@ -73,8 +77,9 @@ live in [`skills/narration`](https://github.com/Lee-W/maigo/blob/main/skills/nar
 - **ruff 只能經 pre-commit 跑**：`uv run ruff` 會 `Failed to spawn`；改用
   `uv run pre-commit run --files <files>`。注意 `--all-files` 不掃 untracked 檔，
   新增檔案要明確列進 `--files`。
-- **工具邊界**：venv 工具（`pytest` / `mkdocs` / `pre-commit`）一律用 `uv run` 執行；
-  `hooks/` 底下的腳本與 stdlib-only script 用 `python3` 直接執行，不經 `uv run`。
+- **工具邊界**：venv 工具（`pytest` / `mkdocs` / `pre-commit`）與要求專案 Python 的
+  `scripts/validate_plugin.py` 一律用 `uv run` 執行；`hooks/` 底下的 runtime script
+  與其他 standalone stdlib-only script 用 `python3` 直接執行。
 - **Version bump 由 CI 執行**：`cz bump` 是 CI 的職責，不屬於任何 plan / 任務步驟 /
   open question——規劃或交辦時不得把手動 bump 列為待辦項目。
 - **`scripts/board_serve.py` 的 `V{N}_CSS_SHA256` 常數必須用程式算，不可手填**：每次

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # maigo contributor instructions for Claude Code agents
 
+> **鏡射檔同步**：`CLAUDE.md` 與 `AGENTS.md` 共用下列 contributor conventions。
+> 修改共同規則時必須同步另一份；平台特定措辭、連結格式與 hook runtime 說明可保留差異，
+> 否則另一端會照舊快照做事。
+
 ## Tone
 
 This project is emoji-friendly. When working in this repository
@@ -60,8 +64,9 @@ live in [`skills/narration`](skills/narration/SKILL.md).
 - **ruff 只能經 pre-commit 跑**：`uv run ruff` 會 `Failed to spawn`；改用
   `uv run pre-commit run --files <files>`。注意 `--all-files` 不掃 untracked 檔，
   新增檔案要明確列進 `--files`。
-- **工具邊界**：venv 工具（`pytest` / `mkdocs` / `pre-commit`）一律用 `uv run` 執行；
-  `hooks/` 底下的腳本與 stdlib-only script 用 `python3` 直接執行，不經 `uv run`。
+- **工具邊界**：venv 工具（`pytest` / `mkdocs` / `pre-commit`）與要求專案 Python 的
+  `scripts/validate_plugin.py` 一律用 `uv run` 執行；`hooks/` 底下的 runtime script
+  與其他 standalone stdlib-only script 用 `python3` 直接執行。
 - **Version bump 由 CI 執行**：`cz bump` 是 CI 的職責，不屬於任何 plan / 任務步驟 /
   open question——規劃或交辦時不得把手動 bump 列為待辦項目。
 - **`scripts/board_serve.py` 的 `V{N}_CSS_SHA256` 常數必須用程式算，不可手填**：每次

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Maigo 的 `command-router` skill 會載入對應 `commands/*.md` 作為唯一行
 Codex session 有提供多 agent 工具時，Maigo 會依 command 進行分工；若當前 surface 沒有提供，
 則由主 agent 依相同角色順序執行並明說 fallback。重新開啟 session 後才會載入新安裝的 skills。
 
+更新 Maigo 後也要重新開啟既有 Codex session，讓 skills 與 hook path 重新載入。若 Stop hook
+錯誤仍指向已移除的舊版 cache 路徑（例如 `.../maigo/<old-version>/hooks/...`），代表該 session
+仍持有更新前的 plugin root；關閉該 session 後重新開啟，不要把舊版 cache symlink 當成正式修法。
+
 ## 命令快覽
 
 日常 90% 用這三個：

--- a/agents/Taki.md
+++ b/agents/Taki.md
@@ -76,7 +76,7 @@ diff 動到 `agents/`、`commands/`、`skills/`、`mkdocs.yml`、`docs/` 任一�
 跑兩條驗證取代（或補充）純 pytest：
 
 ```
-python3 scripts/validate_plugin.py
+uv run python scripts/validate_plugin.py
 uv run mkdocs build --strict
 ```
 

--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -137,7 +137,7 @@ manifest 非空 → **一次** spawn 🎀 愛音，把整份 manifest 交給她�
 跑：
 
 ```
-python3 scripts/validate_plugin.py     # stdlib-only → python3
+uv run python scripts/validate_plugin.py
 uv run mkdocs build --strict           # venv 工具 → uv run
 ```
 

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -7,7 +7,9 @@
 ```bash
 git clone <your-fork> maigo
 cd maigo
-pre-commit install      # 一次性，之後 commit 自動跑檢查
+uv python install 3.13
+uv sync --group dev --group docs
+uv run pre-commit install      # 一次性，之後 commit 自動跑檢查
 ```
 
 ## 開發流程
@@ -35,7 +37,7 @@ pre-commit install      # 一次性，之後 commit 自動跑檢查
 ### 升版本或大動結構前，跑完整檢查
 
 ```bash
-python3 scripts/validate_plugin.py
+uv run python scripts/validate_plugin.py
 ```
 
 涵蓋的檢查面向（具體項數會隨 plugin 演進變動，**以 `CHECKS` list 與實際輸出為準**）。

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -103,7 +103,8 @@ Rule dict 的可選欄位。偵測命中時，hook 在 user project 的 `.claude
    開頭寫 `**Loaded by**: repo-detect hook (SessionStart) when <project> is detected`，
    後接 When to apply / 命名 / 環境 / 測試 / PR 等子段。
 
-完成後跑 `python3 scripts/validate_plugin.py` 確認 skill cross-ref 通過（check #8 會抓 `repo_detect.py` 引用的 `skills/<name>/` 是否存在）。
+完成後跑 `uv run python scripts/validate_plugin.py` 確認 skill cross-ref 通過
+（validator 會抓 `repo_detect.py` 引用的 `skills/<name>/` 是否存在）。
 
 ## PostToolUse — `hooks/token_usage.py`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -263,7 +263,7 @@ skill 是**目錄**不是單檔。SKILL.md 本體在 skill 觸發時整份進 co
 3. `mkdocs.yml` 的 `Skills (source):` 段加一條 `- <new-name>: skills/<new-name>.md`
 4. 這份 catalog 表加一列（Owner / Consumers / 摘要）
 5. 在 owner agent 的 prompt 加引用：「process 依 `skills/<new-name>/SKILL.md`」
-6. 跑 `python3 scripts/validate_plugin.py`（cross-ref + 上述 alignment 檢查）
+6. 跑 `uv run python scripts/validate_plugin.py`（cross-ref + 上述 alignment 檢查）
    與 `uv run mkdocs build --strict`（doc link rewrite 不報缺檔）
 
 第 1–4 步漏掉任何一條 → `check_skills_docs_alignment` 會擋下。

--- a/scripts/validate_plugin.py
+++ b/scripts/validate_plugin.py
@@ -7,7 +7,7 @@ command / skill frontmatter, hook script existence + syntax, pre-commit
 config sanity, skill cross-references, plugin↔pyproject version sync, and
 commands/skills ↔ docs alignment.
 
-跑：`python3 scripts/validate_plugin.py`
+跑：`uv run python scripts/validate_plugin.py`
 Exit 0 = 全綠；Exit 1 = 至少一項失敗。輸出最末一行印「全部 N checks 通過」
 或「N/M checks 失敗」——以 N 為準，不必同步任何文件。
 
@@ -722,6 +722,33 @@ def check_skills_graph() -> CheckResult:
     return r
 
 
+def _markdown_h2_section(text: str, heading: str) -> str | None:
+    pattern = rf"^## {re.escape(heading)}\s*$.*?(?=^## |\Z)"
+    match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+    return match.group(0).strip() if match else None
+
+
+def check_contributor_mirror() -> CheckResult:
+    """CLAUDE.md / AGENTS.md 的共同驗證慣例必須逐字一致。"""
+    r = CheckResult("CLAUDE.md ↔ AGENTS.md Verification quirks sync")
+    sections: dict[str, str] = {}
+    for filename in ("CLAUDE.md", "AGENTS.md"):
+        path = ROOT / filename
+        if not path.is_file():
+            r.fail(f"{filename} 不存在")
+            continue
+        section = _markdown_h2_section(
+            path.read_text(encoding="utf-8"), "Verification quirks"
+        )
+        if section is None:
+            r.fail(f"{filename} 缺 `## Verification quirks` 區段")
+            continue
+        sections[filename] = section
+    if len(sections) == 2 and sections["CLAUDE.md"] != sections["AGENTS.md"]:
+        r.fail("兩份檔案的 `Verification quirks` 不一致，請同步共同規則")
+    return r
+
+
 CHECKS: list[Callable[[], CheckResult]] = [
     check_plugin_json,
     check_hooks_json,
@@ -743,6 +770,7 @@ CHECKS: list[Callable[[], CheckResult]] = [
     check_skills_graph,
     check_doc_link_convention,
     check_relative_links,
+    check_contributor_mirror,
 ]
 
 

--- a/skills/maigo-self-check/SKILL.md
+++ b/skills/maigo-self-check/SKILL.md
@@ -26,16 +26,16 @@ diff 動到以下任一路徑時啟用本 skill：
 ## 驗證指令
 
 ```
-python3 scripts/validate_plugin.py
+uv run python scripts/validate_plugin.py
 uv run mkdocs build --strict
 ```
 
-**為什麼分開用不同執行器**：
+**為什麼都用專案環境**：
 
-- `python3 scripts/validate_plugin.py` — `validate_plugin.py` 只用 stdlib，不需要
-  venv 套件；遵守 maigo 慣例「stdlib-only script 用 `python3`」。
+- `uv run python scripts/validate_plugin.py` — validator 使用專案宣告的 Python
+  版本；不受 host 上較舊的系統 `python3` 影響。
 - `uv run mkdocs build --strict` — mkdocs 是 venv 工具（在 `pyproject.toml` 的
-  dev dependency 裡）；遵守「venv 工具用 `uv run`」。
+  docs dependency 裡）。
 
 ## 這兩條抓的是 pytest 抓不到的東西
 
@@ -48,6 +48,7 @@ uv run mkdocs build --strict
 | 相對 link 在 include-markdown rewrite 後炸 strict-mode | `mkdocs build --strict` |
 | docs nav 指到不存在的 page | `mkdocs build --strict` |
 | command 檔缺「掛名」角色台詞（引號旁邊沒有角色 emoji / 名字） | `validate_plugin.py` |
+| `CLAUDE.md` / `AGENTS.md` 的共同驗證慣例漂移 | `validate_plugin.py` |
 
 pytest 測的是 Python 行為；上述問題都在 plugin 結構層——pytest 對它們是盲的。
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,6 +276,17 @@ def make_hooks(tmp_path: Path) -> Path:
     return hooks_dir
 
 
+def make_contributor_mirrors(tmp_path: Path) -> None:
+    """Write the shared contributor section required by validate_plugin.py."""
+    section = "## Verification quirks\n\n- shared rule\n"
+    (tmp_path / "CLAUDE.md").write_text(
+        f"# Claude instructions\n\n{section}", encoding="utf-8"
+    )
+    (tmp_path / "AGENTS.md").write_text(
+        f"# Codex instructions\n\n{section}", encoding="utf-8"
+    )
+
+
 @pytest.fixture
 def plugin_tree(tmp_path: Path) -> Path:
     """Build a minimal valid plugin tree under tmp_path.
@@ -295,4 +306,5 @@ def plugin_tree(tmp_path: Path) -> Path:
     make_mkdocs_yml(tmp_path)
     make_skills_catalog(tmp_path)
     make_hooks(tmp_path)
+    make_contributor_mirrors(tmp_path)
     return tmp_path

--- a/tests/test_validate_plugin.py
+++ b/tests/test_validate_plugin.py
@@ -926,6 +926,80 @@ class TestCheckRelativeLinks:
 
 
 # ---------------------------------------------------------------------------
+# check_contributor_mirror
+# ---------------------------------------------------------------------------
+
+
+class TestCheckContributorMirror:
+    def _write(self, tmp_path: Path, filename: str, body: str) -> None:
+        (tmp_path / filename).write_text(body, encoding="utf-8")
+
+    def test_matching_verification_sections_pass_despite_platform_differences(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        shared = "## Verification quirks\n\n- shared rule\n"
+        self._write(tmp_path, "CLAUDE.md", f"# Claude\n\nClaude-only text\n\n{shared}")
+        self._write(tmp_path, "AGENTS.md", f"# Codex\n\nCodex-only text\n\n{shared}")
+        monkeypatch.setattr(validate_plugin, "ROOT", tmp_path)
+
+        assert validate_plugin.check_contributor_mirror().passed
+
+    def test_drifted_verification_sections_fail(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._write(
+            tmp_path,
+            "CLAUDE.md",
+            "# Claude\n\n## Verification quirks\n\n- Claude rule\n",
+        )
+        self._write(
+            tmp_path,
+            "AGENTS.md",
+            "# Codex\n\n## Verification quirks\n\n- Codex rule\n",
+        )
+        monkeypatch.setattr(validate_plugin, "ROOT", tmp_path)
+
+        result = validate_plugin.check_contributor_mirror()
+
+        assert not result.passed
+        assert any("不一致" in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        ("filename", "body", "expected"),
+        [
+            pytest.param("AGENTS.md", "", "AGENTS.md 不存在", id="missing-file"),
+            pytest.param(
+                "AGENTS.md",
+                "# Codex\n\nNo shared section\n",
+                "AGENTS.md 缺",
+                id="missing-section",
+            ),
+        ],
+    )
+    def test_missing_mirror_input_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        filename: str,
+        body: str,
+        expected: str,
+    ):
+        self._write(
+            tmp_path,
+            "CLAUDE.md",
+            "# Claude\n\n## Verification quirks\n\n- shared rule\n",
+        )
+        if body:
+            self._write(tmp_path, filename, body)
+        monkeypatch.setattr(validate_plugin, "ROOT", tmp_path)
+
+        result = validate_plugin.check_contributor_mirror()
+
+        assert not result.passed
+        assert any(expected in error for error in result.errors)
+
+
+# ---------------------------------------------------------------------------
 # main() happy-path integration (M-1)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Run plugin validation with the project Python and reject drift in shared contributor verification rules. Document stale Codex sessions after plugin updates.