### PR TITLE
fix(codex): disable incompatible Claude lifecycle hooks

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -9,6 +9,9 @@
   "homepage": "https://lee-w.github.io/maigo/",
   "repository": "https://github.com/Lee-W/maigo",
   "skills": "./skills/",
+  "hooks": {
+    "hooks": {}
+  },
   "keywords": [
     "multi-agent",
     "workflow",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,16 +47,16 @@ live in [`skills/narration`](https://github.com/Lee-W/maigo/blob/main/skills/nar
 
 ## Hooks vs Skills boundary
 
-- **`hooks/`** = machine-enforced checks, but only inside a **Claude Code**
-  session — Claude Code's harness runs the scripts under `hooks/` and blocks
-  the turn automatically. Example: 🩵 Tomori 沒寫 plan path →
+- **`hooks/`** = machine-enforced checks inside a **Claude Code** session —
+  Claude Code's harness runs the scripts under `hooks/` and blocks the turn
+  automatically. Example: 🩵 Tomori 沒寫 plan path →
   `teammate_quality_check.py` block；任務宣告完成沒跑 test →
   `verify_completion.py` block.
-  **Codex has no equivalent hook runtime.** When working as a Codex agent,
-  nothing will stop you from skipping what these scripts check — treat each
-  hook script's logic as a required manual step (read it, or run it directly
-  with `python3 hooks/<script>.py` where that's meaningful) rather than
-  something the environment enforces for you.
+  **Codex 也有 lifecycle hook runtime，但 Maigo 的 Codex manifest 會用空的
+  inline hooks 覆蓋這組 Claude Code 專用 hooks**：兩端支援的事件與 I/O schema
+  不完全相同，直接共用會讓 Codex 把 Claude Code 的合法輸出判成錯誤。Codex command
+  會顯式執行 review / verification；其餘 hook 邏輯仍視為必要的手動步驟（閱讀，或在
+  適用時直接執行 `python3 hooks/<script>.py`），不依賴環境自動攔截。
 - **`skills/`** = 知識共享。Prompt-driven 共用 narrative / convention /
   workflow，靠 command / agent 定義檔用 markdown link 引用進 context 才生效
   ——這點在 Claude Code 與 Codex 都一樣，都是「讀了才知道」，不是機器強制。例：
@@ -66,11 +66,11 @@ live in [`skills/narration`](https://github.com/Lee-W/maigo/blob/main/skills/nar
 
 新增 enforcement 時的判斷：
 
-- 「失敗應該擋下整個 turn」→ hook（Claude Code 專屬機制；Codex 端沒有等價
-  runtime，只能靠 agent 自律照做）
+- 「失敗應該擋下整個 turn」→ hook（Claude Code 由 runtime 強制；Codex manifest
+  刻意不載入這組 Claude Code hooks，改由 command 顯式執行或 agent 手動照做）
 - 「失敗只是品質下降、人可自決定要不要做」→ skill 段落
-- 兩者都要：先 skill 寫清楚 narrative、hook 做最小 regex 兜底（Codex 這半邊
-  沒有 hook 兜底，全靠讀過 skill 之後自律）
+- 兩者都要：先 skill 寫清楚 narrative、hook 做最小 regex 兜底（Claude Code）；
+  Codex command 則需顯式涵蓋同一檢查，否則靠讀過 skill 之後自律
 
 ## Verification quirks
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -17,10 +17,11 @@ approve。讓 contributor 進到熟悉的 codebase 時，自動拿到該 repo �
 
 1. 讀 stdin JSON 取 `cwd`（缺欄位 → fallback `os.getcwd()`）
 2. **確保 `.maigo/` 被 git 忽略**（`ensure_maigo_ignored`，見下）
-3. 對 `REPO_RULES` 內每個 rule，依序跑其 `detectors`
-4. **任一** detector 命中即視為 rule 命中（OR 邏輯）
-5. 命中 → emit `approve` + systemMessage（要求載入 `skills/<skill>/SKILL.md`）
-6. 全部未命中 → emit `approve` + 空 systemMessage（silent）
+3. **記下目前 HEAD**（`_session_head.record`，見下）
+4. 對 `REPO_RULES` 內每個 rule，依序跑其 `detectors`
+5. **任一** detector 命中即視為 rule 命中（OR 邏輯）
+6. 命中 → emit `approve` + systemMessage（要求載入 `skills/<skill>/SKILL.md`）
+7. 全部未命中 → emit `approve` + 空 systemMessage（silent）
 
 ### 目前 registry
 
@@ -47,6 +48,19 @@ commit。
   `.gitignore`、或前次寫入的 exclude）→ 不重複寫；entry 已在 exclude 裡 → 跳過。
 - **fail-open**：非 git repo、git 不存在、timeout 或任何 OS error → 靜默略過，
   不影響 session 啟動。
+
+### Session-start HEAD 記錄
+
+把「session 開始時的 HEAD SHA」寫進 `.maigo/session-head.json`（`{session_id: sha}`），
+供 Stop hook 判斷這個 session 有沒有 commit 過東西。**必須在 rule loop 之前執行**——
+命中 rule 會 emit 並結束 process。
+
+- **為什麼需要**：Stop hook 原本只看 working tree 髒不髒。session 把工作 commit 掉之後
+  tree 是乾淨的，於是驗證被跳過——而那正是最該驗的時刻（東西進了歷史卻沒跑過測試）
+- **不會弄髒 tree**：檔案落在 `.maigo/`，已被上面的 `ensure_maigo_ignored` 排除
+- **上限**：保留最近 200 個 session，超過丟最舊的（dict 插入序）
+- **Fail-quiet**：非 git repo、repo 尚無任何 commit、缺 `session_id`、寫檔失敗 → 不記錄。
+  Stop hook 查不到記錄時視為「不知道」，**不會**因此強制跑 test（見下）
 
 ### `claude_config_seeds`
 
@@ -253,7 +267,12 @@ message 強調「這不是 test fail，是 import 錯」。
 
 - 偵測不到任何專案類型（沒有 `uv.lock` / `pyproject.toml` / `package.json` / `Cargo.toml` / `go.mod`）→ approve（no-op）
 - `.claude/skip-test-verification` 存在 → approve 並記錄原因
-- **本次 session 無未提交的檔案修改**（read-only session）→ approve，跳過 test 驗證。偵測方式：`git status --porcelain` 回傳 exit 0 且 stdout 為空；`returncode != 0`（非 git repo 等）→ fail-open，照常跑 test
+- **本次 session 無檔案修改**（read-only session）→ approve，跳過 test 驗證。**兩個條件都成立**才跳過：
+    1. working tree 乾淨——`git status --porcelain` 回傳 exit 0 且 stdout 為空；`returncode != 0`（非 git repo 等）→ fail-open，照常跑 test
+    2. HEAD 未離開 SessionStart 記下的 SHA（`_session_head.head_moved`）——所以 commit 過的 session 照樣會被驗
+  查不到本 session 的 HEAD 記錄時視為「不知道」→ 只看條件 1，維持舊行為。這是刻意的：
+  部分 harness 不跑 SessionStart hook，若在那裡把「不知道」當成「有改動」，每個唯讀
+  session 都會被拖去跑整套測試
 - stdin JSON 解析失敗或無 `cwd` 欄位 → fallback 到 `os.getcwd()`，照常嘗試偵測；如果偵測不到還是會 no-op approve
 
 ## 觀察 hook 行為

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1,7 +1,10 @@
 # Hooks Reference
 
-Maigo 註冊四個 hook，定義在 `hooks/hooks.json`。
-只要 plugin 載入就自動生效，使用者不用設定。
+Maigo 的 Claude Code plugin 註冊四個 hook，定義在 `hooks/hooks.json`。
+只要 Claude Code plugin 載入就自動生效，使用者不用設定。
+
+Codex manifest 會用空的 inline hooks 覆蓋這組 Claude Code lifecycle hooks；
+Codex command 仍會顯式執行 review / verification，不共用兩端不同的 hook I/O schema。
 
 ## SessionStart — `hooks/repo_detect.py`
 

--- a/hooks/_session_head.py
+++ b/hooks/_session_head.py
@@ -1,0 +1,101 @@
+"""Shared session-start HEAD record used by Maigo hooks.
+
+`verify_completion.py` needs to answer "did this session change tracked
+files?". A dirty working tree answers yes, but a session that *commits* its
+work leaves the tree clean — and that is exactly the moment verification
+matters most (the work is now in history, unverified). Comparing HEAD against
+the SHA recorded by `repo_detect.py` at SessionStart closes that gap.
+
+The record lives in `.maigo/`, which `repo_detect.ensure_maigo_ignored` keeps
+out of `git status`, so writing it cannot itself make the tree look dirty.
+
+Failures (not a git repo, git missing, OSError) → no record / no signal
+(fail-quiet). Callers must treat "no record" as "unknown", never as "changed";
+some harnesses disable SessionStart hooks, and turning every read-only session
+into a full test run would be worse than the gap this closes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+LOG_PATH = Path(".maigo/session-head.json")
+GIT_TIMEOUT_SEC = 5
+# Cap the record so a long-lived checkout does not accumulate one entry per
+# session forever. Only the current session's entry is ever read.
+MAX_ENTRIES = 200
+
+
+def current_head(cwd: Path) -> str | None:
+    """Return the current HEAD SHA, or None outside a git repo / on any error.
+
+    Also None in a freshly `git init`-ed repo with no commits yet: there is no
+    HEAD to compare against, so such a session falls back to the dirty-tree
+    check alone.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(cwd),
+            capture_output=True,
+            timeout=GIT_TIMEOUT_SEC,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.decode("utf-8", errors="replace").strip() or None
+
+
+def read_records(path: Path) -> dict[str, str]:
+    """Read the session → HEAD mapping; missing or corrupted file is empty."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {k: v for k, v in data.items() if isinstance(k, str) and isinstance(v, str)}
+
+
+def record(cwd: Path, session_id: object) -> bool:
+    """Record the HEAD this session starts at. Returns True if written."""
+    if not isinstance(session_id, str) or not session_id:
+        return False
+    head = current_head(cwd)
+    if head is None:
+        return False
+
+    path = cwd / LOG_PATH
+    records = read_records(path)
+    records[session_id] = head
+    if len(records) > MAX_ENTRIES:
+        # dicts keep insertion order, so this drops the oldest sessions
+        records = dict(list(records.items())[-MAX_ENTRIES:])
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(records, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+    except OSError:
+        return False
+    return True
+
+
+def head_moved(cwd: Path, session_id: object) -> bool:
+    """Return True if HEAD differs from the SHA recorded at session start.
+
+    False when there is no record for this session — "unknown", not "changed".
+    """
+    if not isinstance(session_id, str) or not session_id:
+        return False
+    start = read_records(cwd / LOG_PATH).get(session_id)
+    if not start:
+        return False
+    head = current_head(cwd)
+    if head is None:
+        return False
+    return head != start

--- a/hooks/repo_detect.py
+++ b/hooks/repo_detect.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _hook_io import emit  # noqa: E402
+from _session_head import record as record_session_head  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -234,6 +235,11 @@ def main() -> None:
         # project this is — every command (go/quick/team/review/address-comments)
         # writes into .maigo/.
         ensure_maigo_ignored(cwd)
+
+        # Record the HEAD this session starts at so the Stop hook can tell a
+        # read-only session from one that committed its work. Must happen
+        # before the rule loop below — a matching rule emits and exits.
+        record_session_head(Path(cwd), data.get("session_id"))
 
         for rule in REPO_RULES:
             try:

--- a/hooks/verify_completion.py
+++ b/hooks/verify_completion.py
@@ -2,7 +2,9 @@
 """Maigo Stop hook：任務宣告完成前強制跑 test。
 
 偵測專案類型 → 跑對應 test 指令 → 失敗就 block。即使 orchestrator
-跳過立希也擋下；defense in depth。Host build-env 失敗（CMake、native
+跳過立希也擋下；defense in depth。「本 session 動過東西」= working tree 髒
+**或** HEAD 已離開 SessionStart 記下的 SHA——後者讓已 commit 的工作照樣被驗，
+那正是最該驗的時刻（東西進了歷史卻沒跑過測試）。Host build-env 失敗（CMake、native
 wheel build 等）一律 emit skip——那不是 test 失敗，是 host 環境問題。
 
 支援的設定檔（放在 user 專案的 `.claude/` 下）：
@@ -26,6 +28,7 @@ from typing import NoReturn
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _hook_io import emit  # noqa: E402
 from _retry_log import record_and_count  # noqa: E402
+from _session_head import head_moved  # noqa: E402
 from _token_usage import LOG_PATH, format_one_line, summarize  # noqa: E402
 
 TEST_TIMEOUT_SEC = 90
@@ -243,9 +246,9 @@ def main() -> None:
     claude_dir = cwd / ".claude"
     session_id = data.get("session_id")
 
-    if not has_git_modifications(cwd):
+    if not has_git_modifications(cwd) and not head_moved(cwd, session_id):
         approve_with_usage(
-            "立希 (Taki)：本次 session 無未提交的檔案修改，跳過 test 驗證",
+            "立希 (Taki)：本次 session 無檔案修改（working tree 乾淨且 HEAD 未變動），跳過 test 驗證",
             cwd,
             session_id,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ pythonpath = ["."]
 python_version = "3.13"
 
 [[tool.mypy.overrides]]
-module = ["_frontmatter", "_hook_io", "_retry_log", "_token_usage"]
+module = ["_frontmatter", "_hook_io", "_retry_log", "_session_head", "_token_usage"]
 ignore_missing_imports = true
 
 [tool.commitizen]

--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -39,6 +39,12 @@ def test_codex_manifest_is_valid_and_matches_project_version() -> None:
     assert all(len(prompt) <= 128 for prompt in interface["defaultPrompt"])
 
 
+def test_codex_manifest_disables_claude_lifecycle_hooks() -> None:
+    manifest = json.loads(CODEX_MANIFEST.read_text(encoding="utf-8"))
+
+    assert manifest["hooks"] == {"hooks": {}}
+
+
 def test_codex_router_dispatches_every_command() -> None:
     router = ROUTER.read_text(encoding="utf-8")
     commands = sorted((ROOT / "commands").glob("*.md"))

--- a/tests/test_repo_detect.py
+++ b/tests/test_repo_detect.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
 
 import hooks.repo_detect as rd
+from hooks import _session_head
 from tests.conftest import run_hook_main
 
 
@@ -253,6 +255,59 @@ def _raise_timeout_expired(*args, **kwargs):
 # ---------------------------------------------------------------------------
 # ensure_maigo_ignored
 # ---------------------------------------------------------------------------
+
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=path,
+        capture_output=True,
+        env=GIT_ENV,
+        check=True,
+    )
+
+
+class TestRecordsSessionHead:
+    def test_records_head_for_plain_repo(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _init_repo(tmp_path)
+
+        run_hook_main(
+            rd, {"cwd": str(tmp_path), "session_id": "sess-1"}, monkeypatch, capsys
+        )
+
+        records = _session_head.read_records(tmp_path / _session_head.LOG_PATH)
+        assert records == {"sess-1": _session_head.current_head(tmp_path)}
+
+    def test_recorded_file_is_git_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """The record must not make the working tree look dirty."""
+        _init_repo(tmp_path)
+
+        run_hook_main(
+            rd, {"cwd": str(tmp_path), "session_id": "sess-1"}, monkeypatch, capsys
+        )
+
+        assert (tmp_path / _session_head.LOG_PATH).is_file()
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        )
+        assert status.stdout.decode().strip() == ""
 
 
 class TestEnsureMaigoIgnored:

--- a/tests/test_session_head.py
+++ b/tests/test_session_head.py
@@ -1,0 +1,176 @@
+"""Tests for hooks._session_head."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hooks import _session_head
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def init_repo(path: Path) -> str:
+    """Init a repo with one empty commit; return its HEAD sha."""
+    subprocess.run(["git", "init"], cwd=path, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=path,
+        capture_output=True,
+        env=GIT_ENV,
+        check=True,
+    )
+    head = _session_head.current_head(path)
+    assert head is not None
+    return head
+
+
+def commit_empty(path: Path, message: str) -> str:
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", message],
+        cwd=path,
+        capture_output=True,
+        env=GIT_ENV,
+        check=True,
+    )
+    head = _session_head.current_head(path)
+    assert head is not None
+    return head
+
+
+# ---------------------------------------------------------------------------
+# current_head
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentHead:
+    def test_returns_sha_in_repo(self, tmp_path: Path):
+        head = init_repo(tmp_path)
+        assert len(head) == 40
+
+    def test_non_git_dir_returns_none(self, tmp_path: Path):
+        assert _session_head.current_head(tmp_path) is None
+
+    def test_repo_without_commits_returns_none(self, tmp_path: Path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        assert _session_head.current_head(tmp_path) is None
+
+    def test_git_not_found_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        def raise_not_found(*args, **kwargs):
+            raise FileNotFoundError
+
+        monkeypatch.setattr(subprocess, "run", raise_not_found)
+        assert _session_head.current_head(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# record / read_records
+# ---------------------------------------------------------------------------
+
+
+class TestRecord:
+    def test_writes_session_head(self, tmp_path: Path):
+        head = init_repo(tmp_path)
+        assert _session_head.record(tmp_path, "sess-1") is True
+        stored = json.loads((tmp_path / _session_head.LOG_PATH).read_text())
+        assert stored == {"sess-1": head}
+
+    def test_second_session_appends(self, tmp_path: Path):
+        head = init_repo(tmp_path)
+        _session_head.record(tmp_path, "sess-1")
+        _session_head.record(tmp_path, "sess-2")
+        stored = _session_head.read_records(tmp_path / _session_head.LOG_PATH)
+        assert stored == {"sess-1": head, "sess-2": head}
+
+    def test_non_git_dir_records_nothing(self, tmp_path: Path):
+        assert _session_head.record(tmp_path, "sess-1") is False
+        assert not (tmp_path / _session_head.LOG_PATH).exists()
+
+    def test_missing_session_id_records_nothing(self, tmp_path: Path):
+        init_repo(tmp_path)
+        assert _session_head.record(tmp_path, None) is False
+        assert _session_head.record(tmp_path, "") is False
+        assert not (tmp_path / _session_head.LOG_PATH).exists()
+
+    def test_prunes_to_max_entries(self, tmp_path: Path):
+        head = init_repo(tmp_path)
+        path = tmp_path / _session_head.LOG_PATH
+        path.parent.mkdir(parents=True, exist_ok=True)
+        old = {f"old-{i}": head for i in range(_session_head.MAX_ENTRIES + 10)}
+        path.write_text(json.dumps(old), encoding="utf-8")
+
+        _session_head.record(tmp_path, "newest")
+        stored = _session_head.read_records(path)
+        assert len(stored) == _session_head.MAX_ENTRIES
+        assert "newest" in stored
+        assert "old-0" not in stored  # oldest dropped first
+
+    def test_corrupted_file_is_replaced_not_raised(self, tmp_path: Path):
+        head = init_repo(tmp_path)
+        path = tmp_path / _session_head.LOG_PATH
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+
+        assert _session_head.record(tmp_path, "sess-1") is True
+        assert _session_head.read_records(path) == {"sess-1": head}
+
+    def test_read_records_ignores_non_string_values(self, tmp_path: Path):
+        path = tmp_path / "rec.json"
+        path.write_text(json.dumps({"a": "sha", "b": 3, "c": None}), encoding="utf-8")
+        assert _session_head.read_records(path) == {"a": "sha"}
+
+
+# ---------------------------------------------------------------------------
+# head_moved
+# ---------------------------------------------------------------------------
+
+
+class TestHeadMoved:
+    def test_false_when_head_unchanged(self, tmp_path: Path):
+        init_repo(tmp_path)
+        _session_head.record(tmp_path, "sess-1")
+        assert _session_head.head_moved(tmp_path, "sess-1") is False
+
+    def test_true_after_a_commit(self, tmp_path: Path):
+        init_repo(tmp_path)
+        _session_head.record(tmp_path, "sess-1")
+        commit_empty(tmp_path, "work done in this session")
+        assert _session_head.head_moved(tmp_path, "sess-1") is True
+
+    def test_false_without_a_record(self, tmp_path: Path):
+        """No SessionStart record means "unknown" — must not force a test run."""
+        init_repo(tmp_path)
+        commit_empty(tmp_path, "committed by some earlier session")
+        assert _session_head.head_moved(tmp_path, "sess-1") is False
+
+    def test_false_for_a_different_session(self, tmp_path: Path):
+        init_repo(tmp_path)
+        _session_head.record(tmp_path, "sess-1")
+        commit_empty(tmp_path, "work")
+        assert _session_head.head_moved(tmp_path, "other-session") is False
+
+    def test_false_without_session_id(self, tmp_path: Path):
+        init_repo(tmp_path)
+        _session_head.record(tmp_path, "sess-1")
+        commit_empty(tmp_path, "work")
+        assert _session_head.head_moved(tmp_path, None) is False
+
+    def test_false_when_head_unreadable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        init_repo(tmp_path)
+        _session_head.record(tmp_path, "sess-1")
+        monkeypatch.setattr(_session_head, "current_head", lambda cwd: None)
+        assert _session_head.head_moved(tmp_path, "sess-1") is False

--- a/tests/test_verify_completion.py
+++ b/tests/test_verify_completion.py
@@ -299,6 +299,46 @@ class TestMain:
         assert "Token usage：input 1.2k" in result["reason"]
         assert "已追蹤 1 agents" in result["reason"]
 
+    def test_clean_tree_and_unmoved_head_skips(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ):
+        # Read-only session: nothing to verify, so the suite must not run.
+        (tmp_path / "uv.lock").touch()
+        monkeypatch.setattr(
+            verify_completion, "has_git_modifications", lambda cwd: False
+        )
+        monkeypatch.setattr(verify_completion, "head_moved", lambda cwd, sid: False)
+        result = run_hook_main(
+            verify_completion, {"cwd": str(tmp_path)}, monkeypatch, capsys
+        )
+        assert result["decision"] == "approve"
+        assert "無檔案修改" in result["reason"]
+
+    def test_clean_tree_but_moved_head_still_verifies(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ):
+        # The session committed its work, so the tree is clean — the suite must
+        # still run. Reaching *any* later branch proves the skip was not taken;
+        # uv-not-in-PATH is the cheapest one that needs no test run.
+        (tmp_path / "uv.lock").touch()
+        monkeypatch.setattr(
+            verify_completion, "has_git_modifications", lambda cwd: False
+        )
+        monkeypatch.setattr(verify_completion, "head_moved", lambda cwd, sid: True)
+        monkeypatch.setattr(verify_completion.shutil, "which", lambda cmd: None)
+        result = run_hook_main(
+            verify_completion, {"cwd": str(tmp_path)}, monkeypatch, capsys
+        )
+        assert result["decision"] == "approve"
+        assert "無檔案修改" not in result["reason"]
+        assert "uv 不在 PATH" in result["reason"]
+
     def test_uv_lock_present_but_uv_not_in_path(
         self,
         tmp_path: Path,


### PR DESCRIPTION
Keep Claude Code hook enforcement unchanged while Codex commands continue to run review and verification explicitly.