### PR TITLE
feat(board): streamline the Work Board reading view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Install Python
         run: uv python install 3.13
 
-      - name: Install dev dependencies
-        run: uv sync --group dev
+      - name: Install dev and docs dependencies
+        run: uv sync --group dev --group docs
 
       - name: Lint
         run: uv run pre-commit run --all-files
@@ -26,9 +26,6 @@ jobs:
 
       - name: Test
         run: uv run pytest
-
-      - name: Install docs deps
-        run: uv sync --group docs
 
       - name: Build docs (strict)
         run: uv run mkdocs build --strict

--- a/commands/address-comments.md
+++ b/commands/address-comments.md
@@ -214,9 +214,11 @@ crystallize 要 spawn 愛音寫 skill，不塞進本 flow。
 [`skills/work-board`](https://github.com/Lee-W/maigo/blob/main/skills/work-board/SKILL.md) 的 upsert 合約
 更新 `.maigo/board.md`：
 
-- 當前 branch 對應的 🔀 你的 PR 行**預設留在 🎯 你的球**，下一步寫 `push ＋ 貼回覆草稿`——步驟 5 的 commit 尚未 push、步驟 6 的回覆草稿尚未送出，球還在使用者手上。只有使用者在這輪之中自行 push 且送出回覆，才移進 ⏳ `等 review`
-- 理由寫「已處理 selected review comments」或更精簡的實際摘要
-- 若仍有 blocked work item，狀態同樣留 🎯，但狀態字改 `有新 comment`，下一步仍是 `/maigo:address-comments`
+- 當前 branch 對應的 🔀 你的 PR 行**預設留在 🎯 你的球**——步驟 5 的 commit 尚未 push、
+  步驟 6 的回覆草稿尚未送出，球還在使用者手上；判斷句寫「push 了嗎——還沒就先 push」。
+  只有使用者在這輪之中自行 push 且送出回覆，才移進 ⏳ `等 review`（判斷句留空）
+- 若仍有 blocked work item，狀態同樣留 🎯，狀態字改 `有新 comment`；判斷句視卡點寫（例：
+  「哪個 work item 卡住——需要你決定」），不寫死固定句子
 
 回寫時必須保留原 checkbox 與 `🧠` 標記；maigo 自己處理的項目不自動勾 checkbox。
 

--- a/commands/board.md
+++ b/commands/board.md
@@ -84,15 +84,19 @@ echo '<[{type, gh_meta, prior_status}, ...]>' | python3 scripts/board_state.py -
 - 首跑在 `.maigo/_serve/` 生成 MkDocs Material scaffold（config ＋ CSS；gitignored
   工作區）；未修改的舊版會自動升級，使用者自訂版會保留並提示合併
 - 導覽只顯示 Work Board；不把 `.maigo/` 所有 report 排在頁面上方
-- 每個球權 section 渲染成「我處理過／項目／作者／改動／狀態／現況／下一步」七欄表格，
-  不做 Kanban 橫向分欄；GitHub item 與 📄 report 皆可直接點開
+- 每個球權 section 渲染成「✓／球／動作」3 欄表格：✓ 欄放 checkbox ＋ `🧠` 學習狀態 ＋
+  可複製 `--check` / `--uncheck` / `--drop` 的操作選單；球欄放型別 emoji ＋ #n ＋ title
+  （主字級）＋ 判斷句（次字級，沒有就不占位）；動作欄放依狀態詞推導出的可複製命令，
+  狀態沒有對應動作就留白。tier 改用列左側色條呈現；作者、`Δ +A/-D`、狀態詞原文、
+  📄 產物、badges 移入每列展開區。不做 Kanban 橫向分欄；GitHub item 與 📄 report
+  皆可直接點開
+- 只有 🎯 你的球 section 預設展開；⏳ / ✅ / 🗄️ 用 `<details>` 預設收起，只顯示標題與計數
 - PR 行從 GitHub `additions` / `deletions` 寫入 `Δ +A/-D`；頁面可搜尋、依類型 / 狀態篩選，
-  並在各球權 section 內依作者、標題或改動量排序，不回寫真相層
+  並在各球權 section 內依標題或改動量排序，不回寫真相層
 - 啟動優先序：repo venv 有 MkDocs Material 與 pymdown-extensions →
   `uv run mkdocs serve`；沒有 → `uvx` 臨時取得套件
-- checkbox 與 `🧠` 學習狀態在表格內保留（唯讀，勾選還是只能改 `board.md`）
-- 每列的「操作」選單可複製 `--check` / `--uncheck` / `--drop` 命令；網頁本身
-  不開寫檔 API、不直接修改 `board.md`
+- checkbox 與 `🧠` 學習狀態在表格內保留（唯讀，勾選還是只能改 `board.md`）；✓ 欄的操作
+  選單只是 clipboard helper，網頁本身不開寫檔 API、不直接修改 `board.md`
 - 改真相層 `board.md` 存檔，served 頁面幾秒內自動更新（mkdocs 內建 live reload）
 - 細節、退場門見 [`skills/work-board` §6](https://github.com/Lee-W/maigo/blob/main/skills/work-board/SKILL.md)
 

--- a/commands/describe-pr.md
+++ b/commands/describe-pr.md
@@ -82,7 +82,7 @@ orchestrator 用 Task tool 啟動燈，把前置 bundle 交給她。燈：
 更新 `.maigo/board.md`：
 
 - 新增 / 更新 🔀 你的 PR 行到 ⏳ `等 review`
-- title 用實際 PR title；理由寫最後活動是你或剛開 PR
+- title 用實際 PR title；判斷句留空（等待中，沒有待決事項）
 
 回寫時必須保留原 checkbox 與 `🧠` 標記。沒有 PR 編號時不猜、不寫 board。
 

--- a/commands/triage-issue.md
+++ b/commands/triage-issue.md
@@ -136,9 +136,9 @@ Queue 還剩 **#Y**, **#Z** — 說 next（「好」/繼續/ok 都行）我再�
 [`skills/work-board`](https://github.com/Lee-W/maigo/blob/main/skills/work-board/SKILL.md) 的 upsert 合約
 更新 `.maigo/board.md`：
 
-- `READY` → 🐛 行進 🎯，下一步命令是 `/maigo:take-issue <n>`
-- `NEEDS_INFO` → 🐛 行進 ⏳，理由寫缺什麼資訊
-- `DUP` / `CLOSE` → 🐛 行進 ✅，附 duplicate / close 理由
+- `READY` → 🐛 行進 🎯（判斷句留空，狀態詞已經講清楚下一步是接工）
+- `NEEDS_INFO` → 🐛 行進 ⏳（判斷句留空；缺什麼資訊寫進狀態詞後面的旁註，不是判斷句）
+- `DUP` / `CLOSE` → 🐛 行進 ✅，duplicate / close 理由寫進狀態詞後面的旁註
 
 board 是本地檔；這不違反本命令「不主動寫 GitHub」原則。回寫時必須保留原 checkbox 與 `🧠` 標記。
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -202,9 +202,9 @@ orchestrator 判斷兩條路徑：
 
 把 issue、自己的 PR、正在 review 的 PR 放進同一份 `.maigo/board.md`，依球權分成
 🎯 你的球 / ⏳ 等別人 / ✅ Merged-closed。`--serve` 用 MkDocs Material 起本地 live reload
-網頁：導覽只留工作板，各球權分區以七欄表格呈現，包含獨立作者欄與 PR
-改動行數；支援搜尋、類型 / 狀態篩選與 section 內排序，不用 Kanban。改 `board.md`
-存檔後瀏覽器直接更新。
+網頁：導覽只留工作板，各球權分區以「✓／球／動作」三欄表格呈現；作者、PR 改動行數、
+狀態詞與產物收進每列的展開區，非 🎯 分區預設收合。頁面支援搜尋、類型 / 狀態篩選，
+以及依標題或改動量做 section 內排序，不用 Kanban。改 `board.md` 存檔後瀏覽器直接更新。
 
 ```
 /maigo:board <targets...>   # 混貼 issue/PR 編號或 URL；入板後刷新

--- a/scripts/board_interactions.js
+++ b/scripts/board_interactions.js
@@ -48,8 +48,8 @@
 
     function compareRows(left, right) {
       const mode = sort.value;
-      if (mode === "author" || mode === "title") {
-        return left.dataset[mode].localeCompare(right.dataset[mode], "zh-Hant");
+      if (mode === "title") {
+        return left.dataset.title.localeCompare(right.dataset.title, "zh-Hant");
       }
       if (mode.startsWith("changes")) {
         const leftChanges = Number(left.dataset.changes);

--- a/scripts/board_serve.py
+++ b/scripts/board_serve.py
@@ -45,11 +45,12 @@ SERVE_DIRNAME = "_serve"
 CONFIG_NAME = "mkdocs.yml"
 CSS_NAME = "board-style.css"
 JS_NAME = "board-interactions.js"
-SCAFFOLD_VERSION = 7
+SCAFFOLD_VERSION = 8
 V3_CSS_SHA256 = "00ca2aabe9c85d5d73a5b6b16cf2f31a4acff990bcaefa7bc57a8fca5c9749b8"
 V4_CSS_SHA256 = "6f578df0d1a502058fc711ed41d31e880112a87cdfb8b9c83e5024a0f1e9937e"
 V5_CSS_SHA256 = "30be21255dc29eb1c74bd4915f07a1d1d49108d9c59618759792bf3c1542b853"
 V6_CSS_SHA256 = "ea2a345279372172ebf68d4049270a74ce20d0dbccd3ab4fb142f115e0602f85"
+V7_CSS_SHA256 = "1696890d9461537ffc7a80789f7641f28ab45dfd193eb3c41b1f6a284769394a"
 
 CONFIG_TEMPLATE = """\
 # maigo-board-scaffold: {version}
@@ -90,7 +91,7 @@ markdown_extensions:
 """
 
 CSS_TEMPLATE = """\
-/* maigo-board-scaffold: 7
+/* maigo-board-scaffold: 8
    maigo work-board serve 樣式——首跑自動生成，改壞了刪掉這個檔案，
    下次跑 board_serve.py 會重新生成預設版本；正常改動請直接編輯這個檔案。 */
 :root {
@@ -108,6 +109,28 @@ CSS_TEMPLATE = """\
   border-radius: 0.45rem;
   background: color-mix(in srgb, var(--md-accent-fg-color) 7%, transparent);
 }
+.board-section-body {
+  margin: 0 0 1.5rem;
+}
+.board-section-body > summary {
+  padding: 0.3rem 0;
+  cursor: pointer;
+  list-style: none;
+  color: var(--board-muted);
+  font-size: 0.82rem;
+}
+.board-section-body > summary::-webkit-details-marker {
+  display: none;
+}
+.board-section-body > summary::before {
+  display: inline-block;
+  margin-right: 0.4rem;
+  transition: transform 0.15s ease;
+  content: "▸";
+}
+.board-section-body[open] > summary::before {
+  transform: rotate(90deg);
+}
 .work-table-wrap {
   width: 100%;
   margin: 0.5rem 0 2rem;
@@ -118,7 +141,7 @@ CSS_TEMPLATE = """\
 .md-typeset .work-table {
   display: table;
   width: 100%;
-  min-width: 58rem;
+  min-width: 46rem;
   margin: 0;
   border: 0;
   font-size: 0.88rem;
@@ -144,28 +167,24 @@ CSS_TEMPLATE = """\
 .md-typeset .work-table tbody tr:hover {
   background: color-mix(in srgb, var(--md-accent-fg-color) 5%, transparent);
 }
+.work-table tbody tr > td:first-child {
+  border-left: 0.3rem solid transparent;
+}
+.work-table tbody tr.status-blocked > td:first-child { border-left-color: #c62828; }
+.work-table tbody tr.status-act > td:first-child { border-left-color: #d65f00; }
+.work-table tbody tr.status-wip > td:first-child { border-left-color: #1565c0; }
+.work-table tbody tr.status-wait > td:first-child { border-left-color: var(--board-border); }
+.work-table tbody tr.status-done > td:first-child { border-left-color: #2e7d32; }
+.work-table tbody tr.status-unknown > td:first-child { border-left-color: #c62828; }
 .handled-cell {
-  width: 4.5rem;
+  width: 5.5rem;
   text-align: center !important;
 }
-.item-cell {
-  width: 23%;
+.ball-cell {
+  width: 65%;
 }
-.author-cell {
-  width: 8rem;
-}
-.diff-cell {
-  width: 6.5rem;
-  white-space: nowrap;
-}
-.status-cell {
-  width: 9rem;
-}
-.reason-cell {
-  width: 26%;
-}
-.next-cell {
-  width: 21%;
+.action-cell {
+  width: 12rem;
 }
 .learn-checkbox {
   width: 1rem;
@@ -182,11 +201,11 @@ CSS_TEMPLATE = """\
 .work-title {
   line-height: 1.4;
 }
-.work-meta,
-.muted {
-  margin-top: 0.2rem;
+.work-reason {
+  margin-top: 0.15rem;
   color: var(--board-muted);
-  font-size: 0.8rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
 }
 .work-status {
   display: inline-block;
@@ -197,27 +216,27 @@ CSS_TEMPLATE = """\
   line-height: 1.4;
   white-space: nowrap;
 }
-.status-blocked {
+.work-status.status-blocked {
   background: color-mix(in srgb, #e53935 16%, transparent);
   color: #c62828;
 }
-.status-act {
+.work-status.status-act {
   background: color-mix(in srgb, #ef6c00 16%, transparent);
   color: #d65f00;
 }
-.status-wip {
+.work-status.status-wip {
   background: color-mix(in srgb, #1565c0 16%, transparent);
   color: #1565c0;
 }
-.status-wait {
+.work-status.status-wait {
   background: color-mix(in srgb, var(--md-default-fg-color) 9%, transparent);
   color: var(--md-default-fg-color);
 }
-.status-done {
+.work-status.status-done {
   background: color-mix(in srgb, #2e7d32 16%, transparent);
   color: #2e7d32;
 }
-.status-unknown {
+.work-status.status-unknown {
   background: color-mix(in srgb, #e53935 8%, transparent);
   color: #c62828;
   border: 1px solid #c62828;
@@ -226,38 +245,33 @@ CSS_TEMPLATE = """\
   margin-left: 0.15rem;
   font-size: 0.8rem;
 }
-[data-md-color-scheme="slate"] .status-blocked { color: #ff8a80; }
-[data-md-color-scheme="slate"] .status-act { color: #ffb36b; }
-[data-md-color-scheme="slate"] .status-wip { color: #82b1ff; }
-[data-md-color-scheme="slate"] .status-wait { color: var(--md-default-fg-color); }
-[data-md-color-scheme="slate"] .status-done { color: #80d88a; }
-[data-md-color-scheme="slate"] .status-unknown { color: #ff8a80; border-color: #ff8a80; }
-.work-command {
-  display: block;
-  width: fit-content;
-  max-width: 100%;
-  margin-bottom: 0.4rem;
-  overflow-wrap: anywhere;
-  white-space: normal;
-}
+[data-md-color-scheme="slate"] .work-status.status-blocked { color: #ff8a80; }
+[data-md-color-scheme="slate"] .work-status.status-act { color: #ffb36b; }
+[data-md-color-scheme="slate"] .work-status.status-wip { color: #82b1ff; }
+[data-md-color-scheme="slate"] .work-status.status-wait { color: var(--md-default-fg-color); }
+[data-md-color-scheme="slate"] .work-status.status-done { color: #80d88a; }
+[data-md-color-scheme="slate"] .work-status.status-unknown { color: #ff8a80; border-color: #ff8a80; }
 .artifact-link {
   display: inline-block;
   margin-bottom: 0.45rem;
   font-size: 0.82rem;
 }
-.row-actions {
+.row-actions,
+.row-detail {
   position: relative;
   width: fit-content;
   margin-top: 0.35rem;
   font-size: 0.8rem;
 }
-.row-actions summary {
+.row-actions summary,
+.row-detail summary {
   color: var(--md-accent-fg-color);
   cursor: pointer;
   list-style: none;
   user-select: none;
 }
-.row-actions summary::-webkit-details-marker {
+.row-actions summary::-webkit-details-marker,
+.row-detail summary::-webkit-details-marker {
   display: none;
 }
 .row-actions-menu {
@@ -269,6 +283,15 @@ CSS_TEMPLATE = """\
   border-radius: 0.35rem;
   background: var(--md-default-bg-color);
   box-shadow: 0 0.25rem 0.8rem rgba(0, 0, 0, 0.14);
+}
+.row-detail-body {
+  display: grid;
+  gap: 0.3rem;
+  margin-top: 0.35rem;
+}
+.row-detail-item {
+  color: var(--board-muted);
+  font-size: 0.82rem;
 }
 .copy-command {
   padding: 0.4rem 0.55rem;
@@ -291,6 +314,21 @@ CSS_TEMPLATE = """\
 }
 [data-md-color-scheme="slate"] .drop-command {
   color: #ff8a80;
+}
+.action-command {
+  display: inline-block;
+  width: fit-content;
+  max-width: 100%;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--board-border);
+  border-radius: 0.35rem;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  text-align: left;
+}
+.action-command:hover {
+  border-color: var(--md-accent-fg-color);
+  background: color-mix(in srgb, var(--md-accent-fg-color) 8%, transparent);
 }
 .learned {
   margin-left: 0.15rem;
@@ -353,7 +391,7 @@ CSS_TEMPLATE = """\
 }
 @media (max-width: 76.234375em) {
   .md-typeset .work-table {
-    min-width: 68rem;
+    min-width: 40rem;
   }
   .work-controls {
     align-items: stretch;
@@ -417,6 +455,10 @@ def _upgrade_generated_config(text: str, site_dir: Path) -> str:
         text = text.replace(
             "# maigo-board-scaffold: 6", f"# maigo-board-scaffold: {SCAFFOLD_VERSION}"
         )
+    elif "# maigo-board-scaffold: 7" in text:
+        text = text.replace(
+            "# maigo-board-scaffold: 7", f"# maigo-board-scaffold: {SCAFFOLD_VERSION}"
+        )
     return text
 
 
@@ -478,6 +520,11 @@ def scaffold(maigo_dir: Path, site_dir: Path) -> Path:
         and "maigo-board-scaffold: 6" in css_text
         and hashlib.sha256(css_text.encode()).hexdigest() == V6_CSS_SHA256
     )
+    upgrade_v7_css = (
+        css_exists
+        and "maigo-board-scaffold: 7" in css_text
+        and hashlib.sha256(css_text.encode()).hexdigest() == V7_CSS_SHA256
+    )
     if (
         not css_exists
         or upgrade_css
@@ -485,6 +532,7 @@ def scaffold(maigo_dir: Path, site_dir: Path) -> Path:
         or upgrade_v4_css
         or upgrade_v5_css
         or upgrade_v6_css
+        or upgrade_v7_css
     ):
         css_path.write_text(CSS_TEMPLATE, encoding="utf-8")
 
@@ -510,6 +558,7 @@ def scaffold(maigo_dir: Path, site_dir: Path) -> Path:
         and not upgrade_v4_css
         and not upgrade_v5_css
         and not upgrade_v6_css
+        and not upgrade_v7_css
     ):
         css_text = css_path.read_text(encoding="utf-8")
         if "maigo-board-scaffold:" not in css_text:
@@ -535,6 +584,11 @@ def scaffold(maigo_dir: Path, site_dir: Path) -> Path:
         elif "maigo-board-scaffold: 6" in css_text:
             sys.stderr.write(
                 "board_serve: 保留自訂的 v6 `board-style.css`；字體放大調整需手動合併\n"
+            )
+        elif "maigo-board-scaffold: 7" in css_text:
+            sys.stderr.write(
+                "board_serve: 保留自訂的 v7 `board-style.css`；"
+                "3 欄表格與列收合樣式需手動合併\n"
             )
 
     return config_path

--- a/scripts/board_serve_hook.py
+++ b/scripts/board_serve_hook.py
@@ -18,24 +18,63 @@ except (
 BOARD_REPO_RE = re.compile(
     r"^# Work Board — (?P<repo>[\w.-]+/[\w.-]+)\s*$", re.MULTILINE
 )
+SECTION_MARKER_RE = re.compile(r"^##\s+(?P<marker>\S+)")
+# 只有 🎯 你的球預設展開；⏳/✅/🗄️ 都預設收合（見 `render_board` 的 section 收合）。
+# 任何 section 只要含有需要注意的列（`_item_needs_attention`），一律強制展開，
+# 不管 marker 是誰——見該函式的說明。
+_DEFAULT_OPEN_SECTION_MARKERS = frozenset({"🎯"})
 ITEM_RE = re.compile(
     r"^\s*-\s+\[(?P<checked>[ xX])\]\s+"
     r"(?P<kind>🐛|🔀|👀)\s+"
     r"(?P<item>(?:[\w.-]+/[\w.-]+)?#\d+)\s+"
-    r"\((?P<person>[^)]*)\)\s+"
+    r"(?:\((?P<person>[^)]*)\)\s+)?"
     r"\*\*(?P<status>[^*]+)\*\*"
     r"(?P<tail>.*)$"
 )
-TITLE_RE = re.compile(r'\s+—\s+"(?P<title>.*)"\s*$')
-ACTION_RE = re.compile(r"\s+→\s+`(?P<action>[^`]+)`")
-ARTIFACT_RE = re.compile(r"\s+📄\s+`(?P<artifact>[^`]+)`")
-DIFF_RE = re.compile(r"\s+Δ\s+\+(?P<additions>\d+)\s*/\s*-(?P<deletions>\d+)")
-
-KIND_LABELS = {
-    "🐛": "Issue",
-    "🔀": "你的 PR",
-    "👀": "Review PR",
-}
+# Tail 逐欄消耗用的錨點。
+#
+# 行文法用 `—` 當欄位分隔符，而 `—` 本身會自然出現在判斷句這種自由文字裡
+# （中文引述、`——` 強調），所以**不能**用「各自 global 掃整行」的 regex 分欄：
+# 掃描鬆（`\s*`）會把判斷句裡的 `—"…"`、`Δ+5/-3` 誤判成本行的欄位；掃描緊
+# （`\s+`）則會在使用者少打一個空格時把整個 title 靜默丟掉。兩者只是把失敗
+# 位置搬來搬去。
+#
+# 這裡改成**位置式解析**：從 `**狀態詞**` 之後由左而右逐欄消耗，每消耗一欄就把
+# 它從剩餘字串前緣切掉，順序固定為
+#   旁註（…）? → Δ +A/-D? → badges? → — "title" → 判斷句 → 📄 `產物`?
+# 判斷句是「其餘剩下的」，因此它含什麼字元都不可能影響前面欄位的判定——
+# 所有 pattern 都錨定在剩餘字串的**開頭**（`^`）或**結尾**（`$`），沒有一個是
+# 對整行做無邊界感知的 `search()`。
+#
+# title 不靠破折號定位，靠它必然存在的引號：讀到 `— "` 之後，往右在「頂層」
+# （沒有正在跳過一組巢狀引號）找第一個「後面接著判斷句分隔符 `—`／`📄` 產物／
+# 行尾」的引號當結尾——所以 title 內含引號（`"Fix "foo" handling"`）不會被
+# 提早截斷，判斷句裡的引號也不會被誤認成 title。頂層引號若沒接到這三種收尾，
+# 只允許它是「開啟一段巢狀引號」（typographic 慣例：開引號前面接空白／行首，
+# 收引號直接貼著前一個字）——貼字的頂層引號沒接到收尾，代表 title／判斷句之間
+# 的分隔符被漏打了，整段解析立刻放棄（不是繼續往右找別的引號硬湊出一個看似
+# 合理的切法）。這裡不再用「跳過的引號數是奇是偶」判斷收尾合不合法：漏打分隔
+# 符的殘句只要恰好含一組成對引號（偶數），奇偶檢查完全抓不到，會把整段判斷句
+# 靜默黏進 title；貼字／空白的開闔字元判定才是真正能區分「合法巢狀引號」跟
+# 「漏打分隔符」的訊號，見 `_consume_leading_title`。
+_NOTE_PAIRS = {"（": "）", "(": ")"}
+_EM_DASH_RE = re.compile("—")
+_LEADING_DIFF_RE = re.compile(r"^\s*Δ\s*\+(?P<additions>\d+)\s*/\s*-(?P<deletions>\d+)")
+_LEADING_BADGE_RE = re.compile(r"^\s*(?P<badge>🧠|💤)")
+_TITLE_OPEN_RE = re.compile(r'^\s*—\s*"')
+# title 收尾引號後面接的**明確分隔符**：判斷句的 `—`，或產物欄的 `📄`。「行尾」
+# 也是合法收尾，但不是靠這個 regex 判斷——見 `_consume_leading_title`。
+_TITLE_SEPARATOR_END_RE = re.compile(r"^\s*(?:—|📄)")
+_TRAILING_ARTIFACT_RE = re.compile(r"\s*📄\s*`(?P<artifact>[^`]+)`\s*$")
+_TRAILING_ACTION_RE = re.compile(r"\s*→\s*`(?P<action>[^`]+)`\s*$")
+# 舊行文法獨有的欄位（新文法已拿掉 `→ 命令`）——出現它就代表這行是舊格式，
+# title 在行尾而不是判斷句之前。新舊格式的判定不能對整個 tail 做無邊界
+# `search()`——新格式的判斷句是自由文字，常會提到「→ `command`」這種措辭
+# （例如引用某個 maigo 命令），若整行掃描就會把合法的新格式行誤判成舊格式，
+# 判斷句被腰斬。判定改為結果導向：先試著把 tail 當新格式解出 leading title，
+# 失敗才試舊格式的 trailing title——哪一次成功就決定 `is_legacy`（見
+# `_consume_title`）；只有 `is_legacy=True` 時才會再去消耗 `_TRAILING_ACTION_RE`，
+# 新格式判斷句就算恰好以 `→ \`command\`` 收尾，也只是自由文字，不會被腰斬。
 
 CHECKBOX_NOTE = """\
 <details class="board-checkbox-note" markdown="1">
@@ -55,7 +94,7 @@ FILTER_CONTROLS = """\
   <label class="search-control"><span>搜尋</span><input id="board-search" type="search" placeholder="標題、作者、狀態…"></label>
   <label><span>類型</span><select id="board-kind"><option value="">全部類型</option><option value="🐛">Issue</option><option value="🔀">你的 PR</option><option value="👀">Review PR</option></select></label>
   <label><span>狀態</span><select id="board-status"><option value="">全部狀態</option></select></label>
-  <label><span>排序</span><select id="board-sort"><option value="board">原本順序</option><option value="author">作者 A→Z</option><option value="title">標題 A→Z</option><option value="changes-desc">改動量：大→小</option><option value="changes-asc">改動量：小→大</option></select></label>
+  <label><span>排序</span><select id="board-sort"><option value="board">原本順序</option><option value="title">標題 A→Z</option><option value="changes-desc">改動量：大→小</option><option value="changes-asc">改動量：小→大</option></select></label>
   <button id="board-reset" type="button">清除</button>
   <span id="board-visible-count" class="visible-count" aria-live="polite"></span>
 </div>
@@ -69,8 +108,10 @@ class BoardItem:
     item: str
     person: str
     status: str
+    note: str
     reason: str
     title: str
+    title_ok: bool
     action: str | None
     artifact: str | None
     learned: bool
@@ -79,43 +120,227 @@ class BoardItem:
     deletions: int | None
 
 
+def _matching_close_index(text: str) -> int | None:
+    """Index of the `）` closing `text[0]`'s bracket, or `None` when unbalanced.
+
+    Nested brackets are counted, and backtick code spans are skipped whole — a
+    branch name annotation like ``（分支 `feat/a）b`）`` must not be cut at the
+    bracket that lives inside the code span.
+    """
+    opener = text[0]
+    closer = _NOTE_PAIRS[opener]
+    depth = 0
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "`":
+            close = text.find("`", index + 1)
+            if close == -1:
+                return None
+            index = close + 1
+            continue
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return None
+
+
+def _consume_notes(rest: str) -> tuple[str, str]:
+    """Consume the 旁註 `（…）` groups that sit right after the status word."""
+    notes: list[str] = []
+    while True:
+        stripped = rest.lstrip()
+        if not stripped or stripped[0] not in _NOTE_PAIRS:
+            break
+        close = _matching_close_index(stripped)
+        if close is None:
+            break
+        notes.append(stripped[: close + 1])
+        rest = stripped[close + 1 :]
+    return " ".join(notes), rest
+
+
+def _consume_diff(rest: str) -> tuple[int | None, int | None, str]:
+    """Consume `Δ +A/-D` **only** at the field position, never mid-sentence."""
+    match = _LEADING_DIFF_RE.match(rest)
+    if match is None:
+        return None, None, rest
+    return (
+        int(match.group("additions")),
+        int(match.group("deletions")),
+        rest[match.end() :],
+    )
+
+
+def _consume_badges(rest: str) -> tuple[bool, bool, str]:
+    """Consume 🧠/💤 badges at the field position (a badge inside the judgment
+    sentence is prose, not a badge)."""
+    learned = stale = False
+    while (match := _LEADING_BADGE_RE.match(rest)) is not None:
+        if match.group("badge") == "🧠":
+            learned = True
+        else:
+            stale = True
+        rest = rest[match.end() :]
+    return learned, stale, rest
+
+
+def _consume_leading_title(text: str) -> tuple[str, str] | None:
+    """Consume a mandatory `— "<title>"` field at the front of `text`.
+
+    Returns `(title, remainder)`, or `None` when the front of `text` is not a
+    well-formed title field — the separator is required, not guessed.
+
+    Scanning is done at "top level" (`inside_nested_quote is False`) unless
+    we've deliberately stepped inside an embedded quoted sub-phrase. At top
+    level, a quote is a valid title-boundary candidate — accepted when it is
+    followed by an explicit separator (`_TITLE_SEPARATOR_END_RE`: ` — `
+    starting 判斷句, or ` 📄 ` starting the artifact field) **or** when
+    nothing else follows on the line at all (a title with no 判斷句).
+
+    A top-level quote that matches neither shape is only allowed to be the
+    *opening* of a legitimate embedded sub-phrase (`"Fix "foo" handling"`) —
+    and typographically, an opening quote is preceded by whitespace (or sits
+    right at the start of the title). If it instead hugs the previous
+    character (`"real title"忘記加分隔符...`), that shape can only be a
+    genuine title's own closing quote that failed to land on a separator —
+    proof the line is malformed, not an embedded quote to skip past. Give up
+    right there instead of continuing to scan for some other quote further
+    down the line that happens to end the string; that used to be decided by
+    whether an even or odd number of quotes were skipped, but a missing
+    separator whose runaway 判斷句 happens to contain one *paired* quote
+    (`"real title"忘記加分隔符 "先別動"`) is structurally indistinguishable
+    from a legitimate nested title under quote-count parity alone — nothing
+    short of the open/close adjacency check actually tells them apart.
+
+    Once inside a nested sub-phrase, the next quote unconditionally closes it
+    (back to top level) — it is not itself evaluated as a boundary candidate,
+    since it's the *inner* phrase's own quote, not the title's.
+    """
+    opening = _TITLE_OPEN_RE.match(text)
+    if opening is None:
+        return None
+    start = opening.end()
+    cursor = start
+    inside_nested_quote = False
+    while (close := text.find('"', cursor)) != -1:
+        remainder = text[close + 1 :]
+        if inside_nested_quote:
+            inside_nested_quote = False
+        else:
+            if _TITLE_SEPARATOR_END_RE.match(remainder) or not remainder.strip():
+                return text[start:close], remainder
+            preceding = text[close - 1] if close > start else ""
+            if preceding and not preceding.isspace():
+                return None
+            inside_nested_quote = True
+        cursor = close + 1
+    return None
+
+
+def _consume_trailing_title(text: str) -> tuple[str, str] | None:
+    """Legacy layout: the title is the last field on the line.
+
+    Anchored from the right — try each `—` from the end backwards and keep the
+    first one whose title field consumes everything up to end-of-line.
+    """
+    for dash in reversed([match.start() for match in _EM_DASH_RE.finditer(text)]):
+        consumed = _consume_leading_title(text[dash:])
+        if consumed is not None and not consumed[1].strip():
+            return consumed[0], text[:dash]
+    return None
+
+
+def _consume_title(text: str) -> tuple[str, str, bool] | None:
+    """Consume the mandatory title field, new-format position first, legacy
+    trailing position as fallback.
+
+    Returns `(title, remainder, is_legacy)`, or `None` when neither position
+    yields a well-formed `— "<title>"` field. `is_legacy` tells
+    `parse_item()` whether a `→ \\`command\\`` still sitting in `remainder`
+    is the legacy action field (only true legacy layout carries one) or just
+    free-text 判斷句 prose that happens to quote a maigo command — see the
+    module-level comment above `_TRAILING_ACTION_RE`.
+    """
+    consumed = _consume_leading_title(text)
+    if consumed is not None:
+        return consumed[0], consumed[1], False
+    consumed = _consume_trailing_title(text)
+    if consumed is not None:
+        return consumed[0], consumed[1], True
+    return None
+
+
+def _strip_trailing(
+    text: str, pattern: re.Pattern[str], group: str
+) -> tuple[str, str | None]:
+    """Consume an end-anchored field (`📄 產物` / legacy `→ 命令`) off `text`."""
+    match = pattern.search(text)
+    if match is None:
+        return text, None
+    return text[: match.start()], match.group(group)
+
+
 def parse_item(line: str) -> BoardItem | None:
-    """Parse one canonical board line; unknown lines stay untouched by the hook."""
+    """Parse one canonical board line; unknown lines stay untouched by the hook.
+
+    Fields are consumed positionally left-to-right (see the anchor block above),
+    so the free-text 判斷句 — the one field users hand-write — is simply
+    "whatever is left" and can contain `—`, `——`, `Δ`, `📄` or quotes without
+    corrupting any earlier field.
+    """
     match = ITEM_RE.fullmatch(line)
     if match is None:
         return None
+    person = match.group("person")
+    if person is None and match.group("kind") != "🔀":
+        return None
 
-    tail = match.group("tail")
-    title_match = TITLE_RE.search(tail)
-    title = title_match.group("title") if title_match else ""
-    if title_match:
-        tail = tail[: title_match.start()]
+    rest = match.group("tail")
+    note, rest = _consume_notes(rest)
+    # Δ 在文法上排在 badges 之前，但手改時容易寫反——兩側都掃一次，寫反了
+    # 也不會讓某個 badge 靜默消失。
+    learned, stale, rest = _consume_badges(rest)
+    additions, deletions, rest = _consume_diff(rest)
+    trailing_learned, trailing_stale, rest = _consume_badges(rest)
+    learned, stale = learned or trailing_learned, stale or trailing_stale
 
-    action_match = ACTION_RE.search(tail)
-    artifact_match = ARTIFACT_RE.search(tail)
-    action = action_match.group("action") if action_match else None
-    artifact = artifact_match.group("artifact") if artifact_match else None
-    learned = "🧠" in tail
-    stale = "💤" in tail
-    diff_match = DIFF_RE.search(tail)
-    additions = int(diff_match.group("additions")) if diff_match else None
-    deletions = int(diff_match.group("deletions")) if diff_match else None
+    # 新格式的 title 就在這個位置；舊格式（有 `→ 命令`）的 title 在行尾。
+    consumed_title = _consume_title(rest)
+    # `consumed_title is None` ＝ 這行沒有可辨識的 `— "…"` title 欄位——不是
+    # 「標題留空」（那會是 `— ""`，仍然解析得到），而是格式壞掉。這種情況不能
+    # 靜默留空，`render_table()` 要大聲顯示、`render_board()` 要強制展開 section
+    # （見 `_item_needs_attention`）。
+    title_ok = consumed_title is not None
+    if consumed_title is not None:
+        title, rest, is_legacy = consumed_title
+    else:
+        title, rest, is_legacy = "", rest, False
 
-    tail = DIFF_RE.sub("", tail)
-    tail = ACTION_RE.sub("", tail)
-    tail = ARTIFACT_RE.sub("", tail)
-    tail = tail.replace("🧠", "")
-    tail = tail.replace("💤", "")
-    reason = tail.strip().removeprefix("—").strip()
+    rest, artifact = _strip_trailing(rest, _TRAILING_ARTIFACT_RE, "artifact")
+    # 只有舊格式才有 `→ 命令` 這個欄位；新格式的判斷句是自由文字，就算恰好以
+    # `→ \`command\`` 收尾也不該被腰斬——見 `_TRAILING_ACTION_RE` 上方註解。
+    action = None
+    if is_legacy:
+        rest, action = _strip_trailing(rest, _TRAILING_ACTION_RE, "action")
+    judgment = rest.strip().removeprefix("—").strip()
 
     return BoardItem(
         checked=match.group("checked").lower() == "x",
         kind=match.group("kind"),
         item=match.group("item"),
-        person=match.group("person"),
+        # 🔀 列（「你的 PR」）可省略 `(你)`——person group 因此是 optional；
+        # 省略時預設顯示「你」。
+        person=person or "你",
         status=match.group("status"),
-        reason=reason,
+        note=note,
+        reason=judgment,
         title=title,
+        title_ok=title_ok,
         action=action,
         artifact=artifact,
         learned=learned,
@@ -161,6 +386,14 @@ def _status_class(status: str) -> str:
     return _TIER_CLASS[tier]
 
 
+def _item_needs_attention(item: BoardItem) -> bool:
+    """列的哪些壞法不能被 section 收合藏住：未知狀態詞（手改壞）、title 解析
+    失敗（格式壞掉靜默丟資料）。`render_board()` 用這個決定要不要強制展開整個
+    section——只在單列層級大聲失敗（`status-unknown`／title 警告框）不夠，
+    使用者要先展開才看得到的話，等於還是靜默落灰。"""
+    return not item.title_ok or _status_class(item.status) == "status-unknown"
+
+
 def _command_target(item: str) -> str:
     """Use a short target in the bound repo and a full target across repos."""
     return item.removeprefix("#")
@@ -175,72 +408,29 @@ def _copy_button(label: str, command: str, css_class: str = "") -> str:
     )
 
 
+def _next_action_command(status: str, target: str) -> str | None:
+    """`next_action_for_status()` ＋ item id 組出可複製命令；沒有下一步就回 `None`。"""
+    next_action = board_state.next_action_for_status(status)
+    if not next_action:
+        return None
+    return f"{next_action} {target}"
+
+
 def render_table(items: list[BoardItem], default_repo: str | None) -> str:
-    """Render a section as one semantic table with compact, layered cells."""
+    """Render a section as one semantic table with 3 scan-friendly columns:
+    `✓`（checkbox ＋ 操作選單）／`球`（型別＋標題＋判斷句，其餘細節收進 `⌄`）／
+    `動作`（可複製的下一步命令）。tier 改用列左側色條呈現，不再獨立一欄。"""
     rows: list[str] = []
     for order, item in enumerate(items):
-        issue_url = _github_url(item, default_repo)
-        item_label = html.escape(item.item)
-        if issue_url:
-            item_label = f'<a class="work-item-id" href="{html.escape(issue_url)}">{item_label}</a>'
+        target = _command_target(item.item)
 
-        title = html.escape(item.title) if item.title else "<em>無標題</em>"
+        # ✓ 欄：checkbox、🧠 與 board 寫入操作。
         learned = (
             '<span class="learned" title="已完成學習盤點">🧠</span>'
             if item.learned
             else ""
         )
-        stale_badge = (
-            '<span class="stale" title="逾期未更新">💤</span>' if item.stale else ""
-        )
-        work_cell = (
-            f'<div class="work-item-title">{item.kind} {item_label} {learned}{stale_badge}</div>'
-            f'<div class="work-title">{title}</div>'
-            f'<div class="work-meta">{html.escape(KIND_LABELS[item.kind])}</div>'
-        )
-        author_cell = f'<span class="work-author">{html.escape(item.person)}</span>'
-
-        if item.additions is not None and item.deletions is not None:
-            changed = item.additions + item.deletions
-            diff_cell = (
-                f'<span class="diff-add">+{item.additions}</span> '
-                f'<span class="diff-delete">−{item.deletions}</span>'
-            )
-        else:
-            changed = -1
-            diff_cell = '<span class="muted">—</span>'
-
         checkbox = " checked" if item.checked else ""
-        done_cell = (
-            '<input class="learn-checkbox" type="checkbox" disabled'
-            f'{checkbox} aria-label="我處理過 {html.escape(item.item)}">'
-        )
-        status_class = _status_class(item.status)
-        status_text = (
-            f"⚠ 未知狀態 {html.escape(item.status)}"
-            if status_class == "status-unknown"
-            else html.escape(item.status)
-        )
-        status_cell = f'<span class="work-status {status_class}">{status_text}</span>'
-        reason_cell = (
-            html.escape(item.reason) if item.reason else '<span class="muted">—</span>'
-        )
-
-        next_parts: list[str] = []
-        if item.action:
-            next_parts.append(
-                f'<code class="work-command">{html.escape(item.action)}</code>'
-            )
-        if item.artifact:
-            artifact_url = _artifact_url(item.artifact)
-            if artifact_url:
-                next_parts.append(
-                    f'<a class="artifact-link" href="{html.escape(artifact_url)}">'
-                    f"📄 {html.escape(item.artifact)}</a>"
-                )
-            else:
-                next_parts.append(f"<code>📄 {html.escape(item.artifact)}</code>")
-        target = _command_target(item.item)
         if item.checked:
             check_action = _copy_button("取消標記", f"maigo:board --uncheck {target}")
         else:
@@ -252,7 +442,102 @@ def render_table(items: list[BoardItem], default_repo: str | None) -> str:
             f"{_copy_button('停止追蹤', f'maigo:board --drop {target}', 'drop-command')}"
             "</div></details>"
         )
-        next_cell = "".join(next_parts) + row_actions
+        done_cell = (
+            '<input class="learn-checkbox" type="checkbox" disabled'
+            f'{checkbox} aria-label="我處理過 {html.escape(item.item)}">'
+            f"{learned}{row_actions}"
+        )
+
+        # 球欄：型別、id、標題與判斷句；其餘細節收進 ⌄。
+        issue_url = _github_url(item, default_repo)
+        item_label = html.escape(item.item)
+        if issue_url:
+            item_label = f'<a class="work-item-id" href="{html.escape(issue_url)}">{item_label}</a>'
+        if item.title_ok:
+            title_html = html.escape(item.title) if item.title else "<em>無標題</em>"
+            title_cell = f'<div class="work-title">{title_html}</div>'
+        else:
+            # title 解析失敗（見 `parse_item` 的 `title_ok`）——比照 status-unknown
+            # 大聲顯示，不留空、不假裝這行沒有標題。
+            title_cell = (
+                '<div class="work-title work-status status-unknown">'
+                "⚠ 無法解析此列（標題遺失，檢查原始格式）</div>"
+            )
+
+        status_class = _status_class(item.status)
+        status_unknown = status_class == "status-unknown"
+        judgment_cell = (
+            f'<div class="work-reason">{html.escape(item.reason)}</div>'
+            if item.reason
+            else ""
+        )
+        # `status-unknown` 必須大聲失敗——不能被收進預設收合的 ⌄ 展開區，
+        # 否則使用者不掃到那一列就永遠看不到手改壞的狀態詞。
+        unknown_warning = (
+            f'<div class="work-status status-unknown">'
+            f"⚠ 未知狀態 {html.escape(item.status)}</div>"
+            if status_unknown
+            else ""
+        )
+
+        detail_items: list[str] = [
+            f'<span class="work-author">{html.escape(item.person)}</span>'
+        ]
+        if item.additions is not None and item.deletions is not None:
+            changed = item.additions + item.deletions
+            detail_items.append(
+                f'<span class="diff-add">+{item.additions}</span> '
+                f'<span class="diff-delete">−{item.deletions}</span>'
+            )
+        else:
+            changed = -1
+        if not status_unknown:
+            note_html = (
+                f' <span class="work-note">{html.escape(item.note)}</span>'
+                if item.note
+                else ""
+            )
+            detail_items.append(
+                f'<span class="work-status {status_class}">'
+                f"{html.escape(item.status)}</span>{note_html}"
+            )
+        elif item.note:
+            detail_items.append(
+                f'<span class="work-note">{html.escape(item.note)}</span>'
+            )
+        if item.artifact:
+            artifact_url = _artifact_url(item.artifact)
+            if artifact_url:
+                detail_items.append(
+                    f'<a class="artifact-link" href="{html.escape(artifact_url)}">'
+                    f"📄 {html.escape(item.artifact)}</a>"
+                )
+            else:
+                detail_items.append(f"<code>📄 {html.escape(item.artifact)}</code>")
+        if item.stale:
+            detail_items.append('<span class="stale" title="逾期未更新">💤</span>')
+        row_detail = (
+            '<details class="row-detail"><summary aria-label="更多細節">⌄</summary>'
+            '<div class="row-detail-body">'
+            + "".join(
+                f'<div class="row-detail-item">{part}</div>' for part in detail_items
+            )
+            + "</div></details>"
+        )
+
+        ball_cell = (
+            f'<div class="work-item-title">{item.kind} {item_label}</div>'
+            f"{title_cell}"
+            f"{judgment_cell}{unknown_warning}{row_detail}"
+        )
+
+        # 動作欄：next_action_for_status() ＋ item id 組出的可複製命令。
+        action_command = _next_action_command(item.status, target)
+        action_cell = (
+            _copy_button(action_command, action_command, "action-command")
+            if action_command
+            else ""
+        )
 
         search_text = " ".join(
             value
@@ -260,6 +545,7 @@ def render_table(items: list[BoardItem], default_repo: str | None) -> str:
                 item.item,
                 item.person,
                 item.status,
+                item.note,
                 item.reason,
                 item.title,
                 item.action,
@@ -267,59 +553,93 @@ def render_table(items: list[BoardItem], default_repo: str | None) -> str:
             if value
         ).casefold()
         rows.append(
-            f'<tr data-kind="{item.kind}" '
-            f'data-author="{html.escape(item.person.casefold())}" '
+            f'<tr class="tier-row {status_class}" data-kind="{item.kind}" '
             f'data-status="{html.escape(item.status)}" '
             f'data-title="{html.escape(item.title.casefold())}" '
             f'data-changes="{changed}" data-order="{order}" '
             f'data-search="{html.escape(search_text)}">'
             f'<td class="handled-cell">{done_cell}</td>'
-            f'<td class="item-cell">{work_cell}</td>'
-            f'<td class="author-cell">{author_cell}</td>'
-            f'<td class="diff-cell">{diff_cell}</td>'
-            f'<td class="status-cell">{status_cell}</td>'
-            f'<td class="reason-cell">{reason_cell}</td>'
-            f'<td class="next-cell">{next_cell}</td>'
+            f'<td class="ball-cell">{ball_cell}</td>'
+            f'<td class="action-cell">{action_cell}</td>'
             "</tr>"
         )
 
     return (
         '<div class="work-table-wrap">\n'
         '<table class="work-table">\n'
-        '<thead><tr><th class="handled-cell">我處理過</th><th>項目</th>'
-        "<th>作者</th><th>改動</th><th>狀態</th><th>現況</th>"
-        "<th>下一步</th></tr></thead>\n"
+        '<thead><tr><th class="handled-cell">✓</th><th>球</th>'
+        "<th>動作</th></tr></thead>\n"
         "<tbody>\n" + "\n".join(rows) + "\n</tbody>\n</table>\n</div>"
     )
 
 
 def render_board(markdown: str) -> str:
-    """Replace each board section's canonical items with one sortable table."""
+    """Replace each board section's canonical items with one sortable table.
+
+    Each `## ` line stays a **real markdown heading** — MkDocs turns it into an
+    `<h2>` (with an id), which is exactly what feeds Material's right-hand TOC
+    nav. Only the *table itself* collapses into a `<details>`: 🎯 你的球
+    defaults open; ⏳/✅/🗄️ default collapsed, showing just the heading (which
+    already carries the count, e.g. `⏳ 等別人（3）`) until clicked open.
+
+    A section's table forces itself open regardless of marker whenever it
+    contains a row that `_item_needs_attention()` — an unknown status word or
+    an unparseable title. Otherwise a hand-broken row could sit inside a
+    collapsed non-🎯 section and never be seen, which is exactly the "silent
+    fade to gray" this hook promises not to do.
+    """
     repo_match = BOARD_REPO_RE.search(markdown)
     default_repo = repo_match.group("repo") if repo_match else None
     lines = markdown.splitlines()
     output: list[str] = []
     pending: list[BoardItem] = []
     deferred: list[str] = []
+    current_marker = ""
 
     def flush() -> None:
-        if pending:
-            output.extend(["", render_table(pending, default_repo), ""])
-            pending.clear()
+        if not pending:
+            return
+        force_open = current_marker in _DEFAULT_OPEN_SECTION_MARKERS or any(
+            _item_needs_attention(item) for item in pending
+        )
+        open_attr = " open" if force_open else ""
+        output.extend(
+            [
+                "",
+                f'<details class="board-section-body"{open_attr} markdown="1">',
+                '<summary class="board-section-toggle">顯示列表</summary>',
+                "",
+                render_table(pending, default_repo),
+                "",
+            ]
+        )
+        pending.clear()
+        if deferred:
             output.extend(deferred)
             deferred.clear()
+        output.extend(["", "</details>", ""])
 
     controls_added = False
     note_added = False
+
     for line in lines:
         if not note_added and line.startswith("# ") and not line.startswith("## "):
             output.append(line)
             output.extend(["", CHECKBOX_NOTE, ""])
             note_added = True
             continue
-        if line.startswith("## ") and not controls_added:
-            output.extend(["", FILTER_CONTROLS, ""])
-            controls_added = True
+        if line.startswith("## "):
+            flush()
+            if not controls_added:
+                output.extend(["", FILTER_CONTROLS, ""])
+                controls_added = True
+            marker_match = SECTION_MARKER_RE.match(line)
+            current_marker = marker_match.group("marker") if marker_match else ""
+            # 原封不動輸出真正的 `## ` heading——MkDocs 才會發出 `<h2>`，TOC
+            # 條目才會回來。不要再把它改寫成 `<summary>`（那樣 Material 的
+            # 右側目錄完全認不到，是這次要修的 regression）。
+            output.extend(["", line, ""])
+            continue
         item = parse_item(line)
         if item is not None:
             pending.append(item)

--- a/scripts/board_state.py
+++ b/scripts/board_state.py
@@ -300,6 +300,14 @@ def tier_for_status(status: str) -> Tier | None:
         return None
 
 
+def next_action_for_status(status: str) -> str | None:
+    """給 UI 用：已知狀態詞回其 `next_action`；未知狀態詞或無預設下一步一律回 `None`。"""
+    try:
+        return _STATUS_META[BoardStatus(status)].next_action
+    except ValueError:
+        return None
+
+
 def _parse_ts(ts: str) -> datetime:
     parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
     if parsed.tzinfo is None:

--- a/skills/work-board/SKILL.md
+++ b/skills/work-board/SKILL.md
@@ -31,37 +31,50 @@ description: This skill should be used when reading, writing, or migrating `.mai
 > 最後刷新：2026-07-09 14:30 ｜ 🎯 3 ｜ ⏳ 2 ｜ ✅ 1 ｜ 🧠 待學習盤點 2
 
 ## 🎯 你的球（3）
-- [ ] 🐛 #123 (alice) **READY** — triage 完可接 → `/maigo:take-issue 123` — "fix xxx"
-- [ ] 🔀 #456 (你) **CHANGES_REQUESTED** Δ +120/-45 — reviewer 要改 → `/maigo:address-comments` — "feat yyy"
-- [x] 👀 #789 (bob) **↩︎ 回你的球** Δ +88/-12 — 你回過後又推新 commit → `/maigo:review 789` — "…"
+- [ ] 🐛 #123 (alice) **READY** — "fix xxx"
+- [ ] 🔀 #456 **CHANGES_REQUESTED** Δ +120/-45 — "feat yyy" — 照改還是回 reviewer
+- [x] 👀 #789 (bob) **↩︎ 回你的球** Δ +88/-12 — "…" — 新 commit 改了多少，值得整個重審嗎 📄 `review-789.md`
 
 ## ⏳ 等別人（2）
-- [ ] 🔀 #460 (你) **等 review** Δ +42/-7 — 最後活動是你 07-08 — "…"
-- [ ] 🐛 #130 (carol) **NEEDS_INFO** — 等回報者補資訊 — "…"
+- [ ] 🔀 #460 **等 review** Δ +42/-7 — "…"
+- [ ] 🐛 #130 (carol) **NEEDS_INFO** — "…"
 
 ## 📥 無法分類（0）
 <!-- 只放 gh 抓不到的（權限 / 打錯號碼 / 網路失敗），抓得到的一律直接分桶 -->
 
 ## ✅ Merged / closed（最近 7 天）
-- [x] 👀 #700 (dave) **APPROVE** Δ +31/-9 🧠 — merged 07-07 — "…"
+- [x] 👀 #700 (dave) **APPROVE**（merged 07-07） Δ +31/-9 🧠 — "…"
 
 ## 🗄️ 已放棄（1）
-- [ ] 🐛 #99 (eve) **已放棄** — `--drop` 軟刪，7 天後可清 — "…"
+- [ ] 🐛 #99 (eve) **已放棄**（`--drop` 軟刪，7 天後可清） — "…"
 ```
 
 ### 行文法
 
+**設計原則：一眼看出要採取的行動、要下的判斷；其餘細節收起來。** 理由欄不是事實紀錄，是判斷句——
+沒有判斷要下就不寫。
+
 ```text
-- [ ] <型別emoji> #<n 或 owner/repo#n> (<作者>) **<狀態詞>** Δ +<additions>/-<deletions> — <一句話理由> → `<下一步命令>` 📄 `<產物路徑>` — "<title>"
+- [ ] <型別emoji> #<n 或 owner/repo#n> (<作者>) **<狀態詞>** Δ +<additions>/-<deletions> <badges> — "<title>" — <判斷句> 📄 `<產物路徑>`
 ```
 
 - **型別 emoji**：🐛 issue ｜ 🔀 你的 PR ｜ 👀 在審的 PR
-- **作者**：issue / PR 的 author；自己的 PR 寫 `(你)`，served 表格會拆成獨立欄位
+- **作者**：issue / PR 的 author；**🔀 你的 PR 整個省略 `(作者)` 欄位**（型別 emoji 已定義
+  「這是你的 PR」，`(你)` 是贅字）；served 表格會把作者收進每列的展開區
 - **`Δ +A/-D`**（PR 必填、issue 省略）：GitHub `additions` / `deletions`；閱讀層另以
   `A + D` 作為「改動量」排序 key
-- **`→ 下一步命令`**：只有 🎯 區的行有——看到就能複製執行，這是「最好讀寫」的核心
+- **badges**（`🧠`/`💤`，optional）：緊接在 `Δ +A/-D` 之後
+- **`"<title>"`**：接在狀態詞／`Δ`／badges 之後——先看狀態與改動量，再看標題
+- **`<判斷句>`（optional，理由欄的新形式）**：只寫「你現在要決定什麼」，**不寫「發生了什麼」**。
+  - 狀態詞本身已經講清楚下一步、或根本沒有判斷要下（例：`可合併`、`等 review`、
+    `IN_PROGRESS`）→ **整段省略**，連前導的 `—` 分隔號一起省略
+  - 真有岔路要選（改還是不改、修還是換路、能不能重現）→ 一句話點出岔路，愈短愈好
+  - 下一步命令**不寫進真相層**——`--serve` 閱讀層由
+    [`scripts/board_state.py`](https://github.com/Lee-W/maigo/blob/main/scripts/board_state.py)
+    的 `next_action_for_status()` 依狀態詞推導成可複製命令（見 §6），真相層與閱讀層因此不會
+    再像舊版一樣各自漂移
 - **`📄 產物路徑`**（optional）：指向這項的本地產物（review-<n>.md / triage 筆記等），相對
-  `.maigo/` 的路徑。沒產物就省略。真相層不塞 markdown link；served 表格
+  `.maigo/` 的路徑，放在整行最後。沒產物就省略。真相層不塞 markdown link；served 表格
   會把它轉成可點的本地 report 連結（見 §6）
 - **checkbox**：`[x]` ＝「這項我**親自**處理過了」（學習閘門訊號，見 §5）；與所在分區正交
 - **🧠 標記**：學習盤點已完成，不重複學
@@ -69,7 +82,18 @@ description: This skill should be used when reading, writing, or migrating `.mai
   `🧠` 一樣是正交於狀態詞的 badge，不影響 bucket / tier
 - **跨 repo**：board 綁 cwd repo（header 記 `gh repo view --json nameWithOwner` 結果）；
   丟進來的 URL 若屬其他 repo，行內用 `owner/repo#n` 全稱
-- 旁註沿用 review board 慣例：DRAFT / 指定 anchor / 他人 review decision 放狀態詞後面
+- **旁註**（沿用 review board 慣例）：branch 名、closed 理由、linked PR、DRAFT、他人 review
+  decision 這類「per-item 事實」寫在狀態詞後面的括弧裡（例：`**IN_PROGRESS**（分支 fix/xxx）`）——
+  旁註記事實，判斷句記決定，兩者不是同一件事
+- **空白容錯**：旁註 `（…）` 與緊接著的 `Δ`／`—` 之間有沒有留空格，parser 都吃得下
+  （nvim 手改最容易漏這格空白）
+- **`— "<title>"` 的 `—` 分隔符是強制的，parser 不會用啟發式猜**：title 前面那個 `—`
+  一定要打，且 title 的收尾引號後面必須緊接著行尾／判斷句的 `—`／`📄` 產物欄三者之一——
+  漏打分隔符（或整段引號打壞）都不會被硬猜出一個看似合理的切法。判斷句本身含引號、
+  `——`、`Δ+N/-M` 這類自由文字完全沒問題（只要 title 自己的分隔符有打對），但只要
+  parser 判定不出合法的 `"<title>"` 欄位，一律回報格式壞掉，`--serve` 閱讀層不會靜默
+  留空——比照未知狀態詞大聲顯示「⚠ 無法解析此列」，並強制展開該列所在的 section
+  （見 §6）
 
 ### 狀態詞 vocabulary（依型別，含 tier）
 
@@ -105,10 +129,11 @@ review verdict 沿用 [`strict-review`](https://github.com/Lee-W/maigo/blob/main
 
 **badge（正交於狀態詞，不佔 bucket）**：`🧠` 已完成學習盤點；`💤` stale——`updatedAt`
 逾 14 天（`scripts/board_state.py --stale-days` 可調），提示這顆球可能被遺忘，不改變 bucket / tier。
-兩者都寫在 `Δ +A/-D` 之後、理由之前，例：`Δ +12/-3 🧠💤 — ...`。
+兩者都寫在 `Δ +A/-D` 之後、title 之前，例：`Δ +12/-3 🧠💤 — "..."`。
 
 **不在 enum 內的狀態詞**（手改壞、或舊工具寫入的殘留字）在 `--serve` 閱讀層會顯示紅框
-「⚠ 未知狀態」，不會靜默落灰——見 §6。
+「⚠ 未知狀態」，且該列所在的 section 會被強制展開（不管 marker 是誰），不會靜默落灰
+——見 §6。
 
 **向下相容**：新 vocab 是舊 vocab 的超集，沒有任何舊狀態詞被移除或改名。第一次
 `/maigo:board` 刷新時，`board_state.py` 的 `classify()` 會用 `prior_status` 重算每一行，
@@ -208,10 +233,10 @@ per-PR queue 排序 / 前置處理（merged / closed / draft 自動 skip 或問�
 | 命令 | 回寫時機 | 行為 |
 |---|---|---|
 | `/maigo:review` | 每顆 PR 出完 report | 本地 verdict → 🎯 留著；已送 GitHub → ⏳ |
-| `/maigo:triage-issue` | 每個 verdict 出爐 | `READY`→🎯（next: take）；`NEEDS_INFO`→⏳；`DUP`/`CLOSE`→✅ 附理由。board 是本地檔，不違反 triage「不主動寫 GitHub」原則 |
+| `/maigo:triage-issue` | 每個 verdict 出爐 | `READY`→🎯（next: take）；`NEEDS_INFO`→⏳；`DUP`/`CLOSE`→✅，duplicate / close 理由放狀態旁註。board 是本地檔，不違反 triage「不主動寫 GitHub」原則 |
 | `/maigo:take-issue` | 開工時＋收尾 | 開工：issue 行標 `IN_PROGRESS` ＋ branch 名；收尾若開了 PR：新增 🔀 行、issue 行旁註 linked PR |
 | `/maigo:describe-pr` | PR 開出後（若使用者說已開） | 新增/更新對應 🔀 行 → ⏳ `等 review` |
-| `/maigo:address-comments` | 步驟 8（全部 work item 走完） | commit 未 push（**預設**——該命令不 push、不替使用者回覆）→ 🎯 留著，下一步 `push ＋ 貼回覆草稿`；使用者已自行 push 且回覆已送出 → ⏳ `等 review` |
+| `/maigo:address-comments` | 步驟 8（全部 work item 走完） | commit 未 push（**預設**——該命令不 push、不替使用者回覆）→ 🎯 留著，判斷句寫「push 了嗎——還沒就先 push」；使用者已自行 push 且回覆已送出 → ⏳ `等 review`（判斷句留空） |
 
 maigo 命令自己處理的項目**不勾 checkbox**——checkbox 專屬「使用者親自處理」的訊號（見 §5）。
 
@@ -263,35 +288,53 @@ maigo 命令自己處理的項目**不勾 checkbox**——checkbox 專屬「使�
 2. **docs_dir 直指 `.maigo/`**：`board.md` 跟其他 `.md`（📄 連結的 review report 等產物）
    由同一個 server 直接渲染——不再有另外的 render 步驟，也不再另外產生一份閱讀層檔案。
 3. **表格 hook**：[`scripts/board_serve_hook.py`](https://github.com/Lee-W/maigo/blob/main/scripts/board_serve_hook.py)
-   只在渲染 `board.md` 時把每個球權分區的單行資料轉成七欄表格：「我處理過、項目、
-   作者、改動、狀態、現況、下一步」。不做 Kanban 橫向分欄；依然保留球權 section 的語意。
-   狀態欄底色查 `board_state.tier_for_status()`，回 5 個 tier class
-   （`status-blocked/act/wip/wait/done`）而非固定四色；不在 enum 內的狀態詞回
-   `status-unknown`（紅框 + 「⚠ 未知狀態」字樣），不靜默落灰。
-4. **可點的閱讀層**：`#n` 會連到 GitHub issue / PR，`📄 \`路徑\`` 會連到同站渲染的
+   只在渲染 `board.md` 時把每個球權分區的單行資料轉成 **3 欄表格**，貫徹「一眼看出要
+   做什麼」：
+   - **✓**：checkbox ＋ `🧠` 學習狀態 ＋ 每列的操作選單（複製 `--check` / `--uncheck` /
+     `--drop`，原本獨立的「下一步」欄併進這裡）
+   - **球**：`<型別 emoji> #<n>` ＋ title（主字級）＋ 判斷句（次字級，沒有就不占位）
+   - **動作**：由
+     [`board_state.next_action_for_status()`](https://github.com/Lee-W/maigo/blob/main/scripts/board_state.py)
+     依狀態詞 ＋ item id 組出的可複製命令按鈕；狀態沒有對應動作（例：`可合併`、`WIP`）
+     就留白，不印 `—` 佔位
+
+   tier 不再用整欄狀態 pill，改成**列左側色條**（5 個 tier class
+   `status-blocked/act/wip/wait/done`）；不在 enum 內的狀態詞色條變紅框並顯示
+   「⚠ 未知狀態」，`"<title>"` 解析失敗時同樣顯示紅框「⚠ 無法解析此列」，兩者都不
+   靜默落灰。作者、`Δ +A/-D`、狀態詞原文、📄 產物、badges 全部移入每列的 `⌄`
+   展開區，預設收起，不佔一眼掃過的視野。
+4. **section 標題保留為真正的 heading**：`## ` 這行照原樣輸出，MkDocs 照舊發出
+   `<h2>`——Material 右側「目錄」的 section 條目因此不受影響；**只有表格本體**
+   包進 `<details>` 收合，標題本身不收合、一直看得到（含它已經帶的計數）。
+5. **section 預設收合**：只有 `🎯 你的球` 預設展開；`⏳ 等別人` / `✅ Merged-closed` /
+   `🗄️ 已放棄` 的表格用 `<details>` 預設收起，點開才看內容——跟真相層「你現在該動
+   的排最前面」同一種優先權排序，只是多了「其餘先收起來」。**例外**：任何 section
+   只要含有「⚠ 未知狀態」或「⚠ 無法解析此列」的列，不管 marker 是誰，一律強制展開
+   ——大聲失敗若被非 🎯 分區的收合藏住，等於還是靜默落灰。
+6. **可點的閱讀層**：`#n` 會連到 GitHub issue / PR，`📄 \`路徑\`` 會連到同站渲染的
    本地 report。導覽只列 Work Board，不把 `.maigo/` 內所有 report 擠成頂部清單。
-5. **checkbox**：表格保留「我處理過」checkbox 與 `🧠` 學習狀態，但網頁仍是唯讀；
+7. **checkbox**：表格保留「我處理過」checkbox 與 `🧠` 學習狀態，但網頁仍是唯讀；
    勾選回寫一樣只改真相層 `board.md` 本身。`pymdownx.tasklist` 保留作為無法解析行的 fallback。
-6. **篩選與排序**：原生 JavaScript 在閱讀層提供全文搜尋、類型 / 狀態篩選，以及
-   作者、標題、改動量排序。排序只改當下 DOM，且只在各球權 section 內進行；
-   不回寫 `board.md`，不破壞「球到你手上的時間」責任排序。
-7. **列操作選單**：每列可複製 `maigo:board --check` / `--uncheck` / `--drop`。
+8. **篩選與排序**：原生 JavaScript 在閱讀層提供全文搜尋、類型 / 狀態篩選，以及
+   標題、改動量排序（展開區欄位一併納入排序 key）。排序只改當下 DOM，且只在各球權
+   section 內進行；不回寫 `board.md`，不破壞「球到你手上的時間」責任排序。
+9. **列操作選單**：每列可複製 `maigo:board --check` / `--uncheck` / `--drop`，收在 ✓ 欄。
    這只是 clipboard helper；served 頁面不開寫檔 API，不直接變更真相層。
-8. **首頁**：`board.md` 不是 `index.md`——script 不額外造一份 index scaffold 去污染
+10. **首頁**：`board.md` 不是 `index.md`——script 不額外造一份 index scaffold 去污染
    `.maigo/`，直接印出 board 頁網址（`http://<addr>/board/`）。
-9. **啟動優先序**：cwd 專案 venv 已裝 MkDocs Material 與 pymdown-extensions →
+11. **啟動優先序**：cwd 專案 venv 已裝 MkDocs Material 與 pymdown-extensions →
    `uv run mkdocs serve -f <config>`；沒有 →
    `uvx --from mkdocs-material --with pymdown-extensions mkdocs serve -f <config>`
    （zero repo 相依，maigo 在其他 repo 的 `.maigo/` 一樣可用）。
-10. **live reload**：MkDocs 內建 watch，agent 寫 board.md 或使用者 nvim 存檔，served
+12. **live reload**：MkDocs 內建 watch，agent 寫 board.md 或使用者 nvim 存檔，served
    頁面幾秒內更新，不需要手動重跑任何 render 指令。
-11. **退場門**：serve 引擎只是手段——`config` 極小、真相層是純 markdown，隨時可換掉
+13. **退場門**：serve 引擎只是手段——`config` 極小、真相層是純 markdown，隨時可換掉
    整個引擎。Zensical 曾是 v2 原定候選，但實作輪驗證出對 hidden 開頭目錄
    （`.maigo/`）靜默零收錄、symlink 繞法會讓 watcher 追不到真相層變更兩個阻斷性
    問題，v2.1 起降為未來選項（待上游修復再評估回歸；證據見
    `.maigo/board-design.md` §12 修訂段）。v1 的靜態 HTML ＋ pandoc materialize_docs
    渲染腳本已整檔退役，不再維護。
-12. **只能前景執行**：`--serve` 要一直開著終端機、Ctrl-C 結束，不要背景 detach——
+14. **只能前景執行**：`--serve` 要一直開著終端機、Ctrl-C 結束，不要背景 detach——
    父行程被 SIGTERM 終止時子行程會孤兒化佔 port。
 
 ## 7. 跨 session 接續：`ListAgents` 查不到對應 session 時

--- a/tests/fixtures/board_serve_v7.css
+++ b/tests/fixtures/board_serve_v7.css
@@ -1,0 +1,273 @@
+/* maigo-board-scaffold: 7
+   maigo work-board serve 樣式——首跑自動生成，改壞了刪掉這個檔案，
+   下次跑 board_serve.py 會重新生成預設版本；正常改動請直接編輯這個檔案。 */
+:root {
+  --board-border: color-mix(in srgb, var(--md-default-fg-color) 16%, transparent);
+  --board-muted: color-mix(in srgb, var(--md-default-fg-color) 62%, transparent);
+}
+.md-grid {
+  max-width: 92rem;
+}
+.md-content__inner > blockquote:first-of-type {
+  margin: 0 0 1.75rem;
+  padding: 0.8rem 1rem;
+  border: 1px solid var(--board-border);
+  border-left: 0.25rem solid var(--md-accent-fg-color);
+  border-radius: 0.45rem;
+  background: color-mix(in srgb, var(--md-accent-fg-color) 7%, transparent);
+}
+.work-table-wrap {
+  width: 100%;
+  margin: 0.5rem 0 2rem;
+  overflow-x: auto;
+  border: 1px solid var(--board-border);
+  border-radius: 0.55rem;
+}
+.md-typeset .work-table {
+  display: table;
+  width: 100%;
+  min-width: 58rem;
+  margin: 0;
+  border: 0;
+  font-size: 0.88rem;
+}
+.md-typeset .work-table th {
+  padding: 0.65rem 0.75rem;
+  border: 0;
+  border-bottom: 1px solid var(--board-border);
+  background: color-mix(in srgb, var(--md-default-fg-color) 5%, transparent);
+  color: var(--board-muted);
+  font-weight: 650;
+  white-space: nowrap;
+}
+.md-typeset .work-table td {
+  padding: 0.8rem 0.75rem;
+  border: 0;
+  border-bottom: 1px solid var(--board-border);
+  vertical-align: top;
+}
+.md-typeset .work-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+.md-typeset .work-table tbody tr:hover {
+  background: color-mix(in srgb, var(--md-accent-fg-color) 5%, transparent);
+}
+.handled-cell {
+  width: 4.5rem;
+  text-align: center !important;
+}
+.item-cell {
+  width: 23%;
+}
+.author-cell {
+  width: 8rem;
+}
+.diff-cell {
+  width: 6.5rem;
+  white-space: nowrap;
+}
+.status-cell {
+  width: 9rem;
+}
+.reason-cell {
+  width: 26%;
+}
+.next-cell {
+  width: 21%;
+}
+.learn-checkbox {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--md-accent-fg-color);
+}
+.work-item-title {
+  margin-bottom: 0.2rem;
+  font-weight: 700;
+}
+.work-item-id {
+  white-space: nowrap;
+}
+.work-title {
+  line-height: 1.4;
+}
+.work-meta,
+.muted {
+  margin-top: 0.2rem;
+  color: var(--board-muted);
+  font-size: 0.8rem;
+}
+.work-status {
+  display: inline-block;
+  padding: 0.12rem 0.42rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+.status-blocked {
+  background: color-mix(in srgb, #e53935 16%, transparent);
+  color: #c62828;
+}
+.status-act {
+  background: color-mix(in srgb, #ef6c00 16%, transparent);
+  color: #d65f00;
+}
+.status-wip {
+  background: color-mix(in srgb, #1565c0 16%, transparent);
+  color: #1565c0;
+}
+.status-wait {
+  background: color-mix(in srgb, var(--md-default-fg-color) 9%, transparent);
+  color: var(--md-default-fg-color);
+}
+.status-done {
+  background: color-mix(in srgb, #2e7d32 16%, transparent);
+  color: #2e7d32;
+}
+.status-unknown {
+  background: color-mix(in srgb, #e53935 8%, transparent);
+  color: #c62828;
+  border: 1px solid #c62828;
+}
+.stale {
+  margin-left: 0.15rem;
+  font-size: 0.8rem;
+}
+[data-md-color-scheme="slate"] .status-blocked { color: #ff8a80; }
+[data-md-color-scheme="slate"] .status-act { color: #ffb36b; }
+[data-md-color-scheme="slate"] .status-wip { color: #82b1ff; }
+[data-md-color-scheme="slate"] .status-wait { color: var(--md-default-fg-color); }
+[data-md-color-scheme="slate"] .status-done { color: #80d88a; }
+[data-md-color-scheme="slate"] .status-unknown { color: #ff8a80; border-color: #ff8a80; }
+.work-command {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  margin-bottom: 0.4rem;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+.artifact-link {
+  display: inline-block;
+  margin-bottom: 0.45rem;
+  font-size: 0.82rem;
+}
+.row-actions {
+  position: relative;
+  width: fit-content;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+}
+.row-actions summary {
+  color: var(--md-accent-fg-color);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.row-actions summary::-webkit-details-marker {
+  display: none;
+}
+.row-actions-menu {
+  display: grid;
+  min-width: 8rem;
+  margin-top: 0.3rem;
+  overflow: hidden;
+  border: 1px solid var(--board-border);
+  border-radius: 0.35rem;
+  background: var(--md-default-bg-color);
+  box-shadow: 0 0.25rem 0.8rem rgba(0, 0, 0, 0.14);
+}
+.copy-command {
+  padding: 0.4rem 0.55rem;
+  border: 0;
+  border-bottom: 1px solid var(--board-border);
+  background: transparent;
+  color: var(--md-default-fg-color);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.copy-command:last-child {
+  border-bottom: 0;
+}
+.copy-command:hover {
+  background: color-mix(in srgb, var(--md-accent-fg-color) 8%, transparent);
+}
+.drop-command {
+  color: #c62828;
+}
+[data-md-color-scheme="slate"] .drop-command {
+  color: #ff8a80;
+}
+.learned {
+  margin-left: 0.15rem;
+  font-size: 0.8rem;
+}
+.diff-add {
+  color: #2e7d32;
+  font-variant-numeric: tabular-nums;
+}
+.diff-delete {
+  color: #c62828;
+  font-variant-numeric: tabular-nums;
+}
+[data-md-color-scheme="slate"] .diff-add { color: #80d88a; }
+[data-md-color-scheme="slate"] .diff-delete { color: #ff8a80; }
+.work-controls {
+  display: flex;
+  align-items: end;
+  gap: 0.65rem;
+  margin: 0 0 1.5rem;
+  padding: 0.8rem;
+  border: 1px solid var(--board-border);
+  border-radius: 0.55rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 3%, transparent);
+}
+.work-controls label {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 8.5rem;
+  color: var(--board-muted);
+  font-size: 0.75rem;
+}
+.work-controls .search-control {
+  flex: 1;
+  min-width: 12rem;
+}
+.work-controls input,
+.work-controls select,
+.work-controls button {
+  min-height: 2rem;
+  padding: 0.3rem 0.55rem;
+  border: 1px solid var(--board-border);
+  border-radius: 0.35rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  font: inherit;
+}
+.work-controls button {
+  cursor: pointer;
+}
+.visible-count {
+  min-width: 5.5rem;
+  padding-bottom: 0.45rem;
+  color: var(--board-muted);
+  font-size: 0.8rem;
+  text-align: right;
+}
+.work-table tr[hidden] {
+  display: none;
+}
+@media (max-width: 76.234375em) {
+  .md-typeset .work-table {
+    min-width: 68rem;
+  }
+  .work-controls {
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+  .work-controls label {
+    flex: 1 1 10rem;
+  }
+}

--- a/tests/test_board_serve.py
+++ b/tests/test_board_serve.py
@@ -76,7 +76,10 @@ class TestScaffold:
 
         assert ".work-table" in css
         assert ".work-status" in css
-        assert ".work-command" in css
+        assert ".work-status.status-act" in css
+        assert "\n.status-act {" not in css
+        assert ".action-command" in css
+        assert ".row-detail" in css
         assert ".work-controls" in css
         assert ".diff-add" in css
 
@@ -101,8 +104,8 @@ class TestScaffold:
 
         config_path = bs.scaffold(maigo_dir, tmp_path / "site-out")
 
-        assert "maigo-board-scaffold: 7" in config_path.read_text(encoding="utf-8")
-        assert "maigo-board-scaffold: 7" in (serve_dir / "board-style.css").read_text(
+        assert "maigo-board-scaffold: 8" in config_path.read_text(encoding="utf-8")
+        assert "maigo-board-scaffold: 8" in (serve_dir / "board-style.css").read_text(
             encoding="utf-8"
         )
 
@@ -123,7 +126,7 @@ class TestScaffold:
         bs.scaffold(maigo_dir, tmp_path / "site-out")
 
         upgraded = css_path.read_text(encoding="utf-8")
-        assert "maigo-board-scaffold: 7" in upgraded
+        assert "maigo-board-scaffold: 8" in upgraded
         assert "status-blocked" in upgraded
 
     def test_preserves_genuinely_modified_v5_css(self, tmp_path: Path, capsys):
@@ -160,7 +163,7 @@ class TestScaffold:
         bs.scaffold(maigo_dir, tmp_path / "site-out")
 
         upgraded = css_path.read_text(encoding="utf-8")
-        assert "maigo-board-scaffold: 7" in upgraded
+        assert "maigo-board-scaffold: 8" in upgraded
         assert "font-size: 0.88rem" in upgraded
 
     def test_preserves_genuinely_modified_v6_css(self, tmp_path: Path, capsys):
@@ -179,6 +182,43 @@ class TestScaffold:
             "/* maigo-board-scaffold: 6\n   使用者自訂過的版本 */\n.custom {}\n"
         )
         assert "v6" in capsys.readouterr().err
+
+    def test_upgrades_unmodified_v7_css_to_current(self, tmp_path: Path):
+        """Regression: `V7_CSS_SHA256` must match the real, byte-for-byte v7
+        `CSS_TEMPLATE` (pinned as a fixture) — same failure mode as the v5/v6
+        constant bugs this mirrors: a wrong hash makes every genuine
+        pre-existing v7 install look "user-customized" forever."""
+        maigo_dir = tmp_path / ".maigo"
+        serve_dir = maigo_dir / "_serve"
+        serve_dir.mkdir(parents=True)
+        v7_css = (Path(__file__).parent / "fixtures" / "board_serve_v7.css").read_text(
+            encoding="utf-8"
+        )
+        css_path = serve_dir / "board-style.css"
+        css_path.write_text(v7_css, encoding="utf-8")
+
+        bs.scaffold(maigo_dir, tmp_path / "site-out")
+
+        upgraded = css_path.read_text(encoding="utf-8")
+        assert "maigo-board-scaffold: 8" in upgraded
+        assert "board-section" in upgraded
+
+    def test_preserves_genuinely_modified_v7_css(self, tmp_path: Path, capsys):
+        maigo_dir = tmp_path / ".maigo"
+        serve_dir = maigo_dir / "_serve"
+        serve_dir.mkdir(parents=True)
+        css_path = serve_dir / "board-style.css"
+        css_path.write_text(
+            "/* maigo-board-scaffold: 7\n   使用者自訂過的版本 */\n.custom {}\n",
+            encoding="utf-8",
+        )
+
+        bs.scaffold(maigo_dir, tmp_path / "site-out")
+
+        assert css_path.read_text(encoding="utf-8") == (
+            "/* maigo-board-scaffold: 7\n   使用者自訂過的版本 */\n.custom {}\n"
+        )
+        assert "v7" in capsys.readouterr().err
 
     def test_upgrades_v3_config_without_discarding_custom_settings(
         self, tmp_path: Path
@@ -200,7 +240,7 @@ class TestScaffold:
         bs.scaffold(maigo_dir, tmp_path / "new-site")
         text = config_path.read_text(encoding="utf-8")
 
-        assert "maigo-board-scaffold: 7" in text
+        assert "maigo-board-scaffold: 8" in text
         assert "site_name: Custom Board" in text
         assert f"site_dir: {tmp_path / 'new-site'}" in text
         assert "board-interactions.js" in text
@@ -216,6 +256,8 @@ class TestScaffold:
 
         assert "navigator.clipboard.writeText" in script
         assert "data-copy-command" in script
+        assert 'mode === "title"' in script
+        assert 'mode === "author"' not in script
         assert 'table.closest(".work-table-wrap").hidden' in script
         assert "fetch(" not in script
 
@@ -266,6 +308,47 @@ class TestScaffold:
         bs.scaffold(maigo_dir, tmp_path / "site-out")
 
         assert css_path.read_text(encoding="utf-8") == "/* 使用者自訂樣式 */\n"
+
+
+class TestServedPageTableOfContents:
+    """Regression guard for the TOC regression: section headings collapsing
+    into `<summary>` used to make Material's right-hand TOC nav come up
+    completely empty (no real `<h2>` for it to index). Only the table body
+    may collapse — the `## ` heading must stay a real markdown heading."""
+
+    def test_built_board_page_toc_nav_lists_every_section_heading(self, tmp_path: Path):
+        maigo_dir = tmp_path / ".maigo"
+        maigo_dir.mkdir()
+        (maigo_dir / "board.md").write_text(
+            "# Work Board — Lee-W/maigo\n"
+            "\n"
+            "## 🎯 你的球（1）\n"
+            '- [ ] 🐛 #123 (alice) **READY** — "fix parser"\n'
+            "\n"
+            "## ⏳ 等別人（1）\n"
+            '- [ ] 🔀 #460 (你) **等 review** — "add board tables"\n',
+            encoding="utf-8",
+        )
+
+        config_path = bs.scaffold(maigo_dir, tmp_path / "site-out")
+
+        from mkdocs.commands.build import build
+        from mkdocs.config import load_config
+
+        cfg = load_config(str(config_path), strict=True)
+        build(cfg)
+
+        html = (tmp_path / "site-out" / "board" / "index.html").read_text(
+            encoding="utf-8"
+        )
+        nav_start = html.index('<nav class="md-nav md-nav--secondary"')
+        nav_end = html.index("</nav>", nav_start)
+        nav_html = html[nav_start:nav_end]
+
+        assert "🎯 你的球（1）" in nav_html
+        assert "⏳ 等別人（1）" in nav_html
+        # The table itself still collapses — only the heading must stay real.
+        assert 'class="board-section-body"' in html
 
 
 class TestRepoHasMkdocs:

--- a/tests/test_board_serve_hook.py
+++ b/tests/test_board_serve_hook.py
@@ -2,6 +2,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from scripts import board_serve_hook as hook
 
 
@@ -46,17 +48,48 @@ def test_parse_item_accepts_markdown_whitespace_variations():
     assert item.status == "READY"
 
 
+def test_parse_item_new_grammar_title_before_judgment_sentence():
+    """新行文法：title 前移到判斷句之前，且不再有 `→ 命令`（點 A.1/A.2）。"""
+    item = hook.parse_item(
+        '- [ ] 🐛 #9101 (alice) **待 triage** — "CLI 在空設定檔時會 crash" '
+        "— 能重現嗎——不能就 NEEDS_INFO"
+    )
+
+    assert item is not None
+    assert item.title == "CLI 在空設定檔時會 crash"
+    assert item.reason == "能重現嗎——不能就 NEEDS_INFO"
+    assert item.action is None
+
+
+def test_parse_item_own_pr_row_omits_you_person_and_defaults_to_you():
+    """🔀 列可省略 `(你)`（點 A.3）；parser 仍需正確 fullmatch 並補上預設作者。"""
+    item = hook.parse_item('- [ ] 🔀 #9201 **CI 紅** Δ +52/-9 — "Add stale badge"')
+
+    assert item is not None
+    assert item.kind == "🔀"
+    assert item.person == "你"
+    assert item.title == "Add stale badge"
+
+
+@pytest.mark.parametrize("kind", ["🐛", "👀"])
+def test_parse_item_non_own_pr_row_still_requires_author(kind):
+    line = f'- [ ] {kind} #9201 **待 review** Δ +52/-9 — "Missing author"'
+
+    assert hook.parse_item(line) is None
+
+
 def test_render_board_uses_section_tables_and_scan_friendly_columns():
     rendered = hook.render_board(BOARD)
 
     assert rendered.count('<table class="work-table">') == 2
-    assert "我處理過" in rendered
-    assert "項目" in rendered
-    assert "作者" in rendered
-    assert "改動" in rendered
-    assert "狀態" in rendered
-    assert "現況" in rendered
-    assert "下一步" in rendered
+    assert '<th class="handled-cell">✓</th>' in rendered
+    assert "<th>球</th>" in rendered
+    assert "<th>動作</th>" in rendered
+    # 7 欄舊表頭已收斂成 3 欄——舊欄位標題不該再出現（handled-cell 的 aria-label
+    # 仍沿用「我處理過」措辭，只檢查表頭本身已改掉）
+    assert '<th class="handled-cell">我處理過</th>' not in rendered
+    assert "現況" not in rendered
+    assert "下一步" not in rendered
     assert "<th>球權</th>" not in rendered
     assert "- [ ] 🐛 #123" not in rendered
     assert 'class="work-controls"' in rendered
@@ -75,7 +108,7 @@ def test_render_board_keeps_blank_lines_and_comments_in_one_section_table():
     rendered = hook.render_board(board)
 
     assert rendered.count('<table class="work-table">') == 1
-    assert rendered.count("<tr data-kind=") == 2
+    assert rendered.count('data-kind="🐛"') == 2
     assert "<!-- refresh note -->" in rendered
 
 
@@ -114,8 +147,10 @@ def test_render_board_preserves_checkbox_and_badge_semantics():
 def test_render_board_exposes_sort_and_filter_metadata():
     rendered = hook.render_board(BOARD)
 
-    assert 'data-author="bob"' in rendered
+    assert '<option value="author">' not in rendered
+    assert 'data-author="bob"' not in rendered
     assert 'data-status="NEEDS_CHANGES"' in rendered
+    assert 'data-title="tighten validation"' in rendered
     assert 'data-changes="165"' in rendered
     assert '<span class="diff-add">+120</span>' in rendered
     assert '<span class="diff-delete">−45</span>' in rendered
@@ -160,6 +195,393 @@ def test_render_board_marks_unknown_status_with_warning_text():
     assert "手改壞的狀態詞" in rendered
 
 
+def test_render_board_forces_section_open_when_it_holds_unknown_status():
+    """`status-unknown` 不能只在列級大聲失敗——如果它所在的 section 不是 🎯（預設
+    收合），使用者不點開就永遠看不到。任何 marker 只要含有 status-unknown 的列都
+    要強制展開（點 2，對照 SKILL.md §6 的「不會靜默落灰」宣稱）。"""
+    board = (
+        "# Work Board — Lee-W/maigo\n"
+        "## 📥 無法分類（1）\n"
+        '- [ ] 🐛 #9299 (jack) **手改壞的狀態詞** — "title"\n'
+    )
+
+    rendered = hook.render_board(board)
+
+    details_index = rendered.index('<details class="board-section-body"')
+    assert rendered[details_index : details_index + 60].startswith(
+        '<details class="board-section-body" open markdown="1">'
+    )
+
+
+def test_render_board_marks_unparseable_title_with_warning_text():
+    """title 解析失敗（整行找不到 `— "…"` 欄位）比照 status-unknown 大聲顯示，
+    不靜默留空成 `<em>無標題</em>`（點 3/4 (c)）。"""
+    board = (
+        "# Work Board — Lee-W/maigo\n"
+        "## 🎯 你的球（1）\n"
+        "- [ ] 🐛 #1 (alice) **READY** — no quotes anywhere in this line\n"
+    )
+
+    rendered = hook.render_board(board)
+
+    assert "⚠ 無法解析此列" in rendered
+    assert "<em>無標題</em>" not in rendered
+
+
+def test_render_board_forces_section_open_when_title_unparseable():
+    """title 解析失敗也要強制展開所在 section，理由同 status-unknown（點 2 的通用
+    化：「任何 section 只要含有需要注意的列」，不是只硬寫死 📥／status-unknown）。"""
+    board = (
+        "# Work Board — Lee-W/maigo\n"
+        "## ⏳ 等別人（1）\n"
+        "- [ ] 🐛 #1 (alice) **READY** — no quotes anywhere in this line\n"
+    )
+
+    rendered = hook.render_board(board)
+
+    details_index = rendered.index('<details class="board-section-body"')
+    assert rendered[details_index : details_index + 60].startswith(
+        '<details class="board-section-body" open markdown="1">'
+    )
+
+
+def test_parse_item_tolerates_missing_whitespace_around_status_annotation():
+    """狀態詞旁註 `（…）` 與緊接著的 `Δ`／`—` 之間可以沒有空格——nvim 手改最容易漏
+    這格空白，曾經讓要求 `\\s+` 的欄位 regex 完全吃不到、Δ 改動量與 title 被靜默
+    丟掉（點 3/4 (b)，對照 `.maigo/board.md`/SKILL.md 曾經踩過的真實壞行）。
+    現在旁註是位置式消耗掉的，空格有沒有留都不影響後面欄位的定位。"""
+    diff_item = hook.parse_item(
+        '- [x] 👀 #700 (dave) **APPROVE**（merged 07-07）Δ +31/-9 — "no space before delta"'
+    )
+    assert diff_item is not None
+    assert diff_item.additions == 31
+    assert diff_item.deletions == 9
+
+    title_item = hook.parse_item(
+        "- [ ] 🐛 #99 (eve) **已放棄**（`--drop` 軟刪，7 天後可清）"
+        '— "no space before dash"'
+    )
+    assert title_item is not None
+    assert title_item.title_ok is True
+    assert title_item.title == "no space before dash"
+
+
+def test_parse_item_title_ok_false_when_title_grammar_completely_missing():
+    """跟「旁註空白容錯」（上一條測試）不同：這裡整行根本沒有 `"<title>"` 語法，
+    `title_ok` 要能分辨「格式壞掉」跟「有引號但故意留空 `""`」兩種情況。"""
+    broken = hook.parse_item(
+        "- [ ] 🐛 #1 (alice) **READY** — no quotes at all in this line"
+    )
+    assert broken is not None
+    assert broken.title_ok is False
+    assert broken.title == ""
+
+    explicitly_empty = hook.parse_item('- [ ] 🐛 #2 (bob) **READY** — ""')
+    assert explicitly_empty is not None
+    assert explicitly_empty.title_ok is True
+    assert explicitly_empty.title == ""
+
+
+# 判斷句是自由文字：它含什麼字元都不得污染前面的欄位。
+#
+# 下面這批測試釘住的是行文法的根本限制：欄位分隔符 `—` 本身會自然出現在使用者
+# 手寫的判斷句裡（中文引述、`——` 強調），所以欄位不能靠「掃整行找 pattern」來
+# 認。歷史上兩種掃描鬆緊都各自壞過一次：
+#   1. `\\s+`（要求分隔符前有空白）→ 使用者少打一個空格就靜默丟掉整個 title；
+#   2. `\\s*`（不要求空白）→ 判斷句裡的 `—"…"`、`Δ+N/-M` 被誤判成本行的欄位。
+# 現在改成由左而右逐欄消耗、判斷句是「其餘剩下的」，兩種壞法都不成立。
+
+
+def test_parse_item_judgment_may_quote_with_em_dash_without_stealing_title():
+    """判斷句用 em dash 引述別人的話（`使用者說—"先別動"`）時，那組引號不是
+    title 欄位——title 已經在它前面的位置被消耗掉了。"""
+    item = hook.parse_item(
+        '- [ ] 🐛 #701 (alice) **待 triage** — "真 title" '
+        '— 使用者說—"先別動" 要不要照做'
+    )
+
+    assert item is not None
+    assert item.title == "真 title"
+    assert item.title_ok is True
+    assert item.reason == '使用者說—"先別動" 要不要照做'
+
+
+def test_parse_item_quoted_judgment_without_title_stays_intact_and_loud():
+    """同樣的引述，但這行**根本沒有** title 欄位：不能把判斷句裡的引號當成
+    title 撿來用（那會讓判斷句被腰斬且無人察覺），要整句留著並回報格式壞掉。"""
+    item = hook.parse_item(
+        '- [ ] 🐛 #702 (alice) **待 triage** 使用者說—"先別動" 要不要照做'
+    )
+
+    assert item is not None
+    assert item.title_ok is False
+    assert item.title == ""
+    assert item.reason == '使用者說—"先別動" 要不要照做'
+
+
+def test_parse_item_judgment_mentioning_another_items_delta_is_not_this_rows_diff():
+    """判斷句提到「別的 PR 改了多少行」時，那個 `Δ+N/-M` 不是本行的改動量——
+    🐛 issue 本來就沒有 Δ 欄位，不該憑空長出一個。"""
+    issue = hook.parse_item(
+        '- [ ] 🐛 #703 (alice) **待 triage** — "t" — 相關 PR 改了Δ+5/-3的部分'
+    )
+
+    assert issue is not None
+    assert issue.additions is None
+    assert issue.deletions is None
+    assert issue.reason == "相關 PR 改了Δ+5/-3的部分"
+
+
+def test_parse_item_own_delta_wins_over_delta_mentioned_in_judgment():
+    """本行真的有 Δ 欄位時，判斷句裡另一組 `Δ+N/-M` 不得覆蓋它。"""
+    item = hook.parse_item(
+        '- [ ] 🔀 #704 **CI 紅** Δ +52/-9 — "t" — 另一個改動Δ+9/-1 要不要跟'
+    )
+
+    assert item is not None
+    assert (item.additions, item.deletions) == (52, 9)
+    assert item.reason == "另一個改動Δ+9/-1 要不要跟"
+
+
+def test_parse_item_judgment_may_contain_dashes_badges_and_artifact_emoji():
+    """`——`（強調）、`🧠`/`💤`（badge 字面）、裸 `📄`（沒有 backtick 路徑）
+    出現在判斷句裡都只是文字，不得被當成欄位吃掉。"""
+    item = hook.parse_item(
+        '- [ ] 🐛 #705 (alice) **待 triage** — "t" '
+        "— 能重現嗎——不能就 NEEDS_INFO；這要 🧠 想一下，別 💤，附件 📄 也還沒收到"
+    )
+
+    assert item is not None
+    assert item.reason == (
+        "能重現嗎——不能就 NEEDS_INFO；這要 🧠 想一下，別 💤，附件 📄 也還沒收到"
+    )
+    assert item.learned is False
+    assert item.stale is False
+    assert item.artifact is None
+
+
+def test_parse_item_title_may_contain_quotes():
+    """title 內含未跳脫的引號（GitHub PR 標題很常見，如 `Fix "foo" handling`）
+    不得在第一個內層引號就被截斷——收尾引號是「後面接行尾／`—`／`📄`」的那個。"""
+    with_judgment = hook.parse_item(
+        '- [ ] 🐛 #709 (alice) **READY** — "Fix "foo" handling" — 要不要改'
+    )
+    assert with_judgment is not None
+    assert with_judgment.title == 'Fix "foo" handling'
+    assert with_judgment.reason == "要不要改"
+
+    at_line_end = hook.parse_item(
+        '- [ ] 🐛 #710 (alice) **READY** — "Fix "foo" handling"'
+    )
+    assert at_line_end is not None
+    assert at_line_end.title == 'Fix "foo" handling'
+    assert at_line_end.reason == ""
+
+
+def test_parse_item_judgment_ending_with_a_quote_does_not_extend_the_title():
+    """判斷句以引號收尾（`他說"不要"`）時，title 仍然是前面那一組——
+    收尾引號的判定是「第一個合法收尾」，不是「整行最後一個引號」。"""
+    item = hook.parse_item('- [ ] 🐛 #711 (alice) **READY** — "t" — 他說"不要"')
+
+    assert item is not None
+    assert item.title == "t"
+    assert item.reason == '他說"不要"'
+
+
+def test_parse_item_empty_judgment_sentence():
+    """判斷句 optional：省略時 reason 是空字串，不是把 title 或分隔符撿進來。"""
+    item = hook.parse_item('- [ ] 🐛 #712 (alice) **READY** — "t"')
+
+    assert item is not None
+    assert item.title == "t"
+    assert item.reason == ""
+
+
+def test_parse_item_status_annotation_may_nest_brackets_and_backticks():
+    """旁註 `（…）` 內含巢狀全形括號、以及 backtick code span 裡的 `）`——
+    括號配對要跳過 code span，否則旁註會在錯的地方被切斷、Δ 跟著解析不到。"""
+    item = hook.parse_item(
+        "- [ ] 🐛 #713 (alice) **IN_PROGRESS**（分支 `feat/a）b`（外層））"
+        'Δ +1/-2 — "t" — 判斷'
+    )
+
+    assert item is not None
+    assert (item.additions, item.deletions) == (1, 2)
+    assert item.title == "t"
+    assert item.note == "（分支 `feat/a）b`（外層））"
+    assert item.reason == "判斷"
+
+
+def test_parse_item_legacy_grammar_without_next_action_command():
+    """向下相容：舊格式沒有 `→ 命令` 的行（title 一樣在行尾）。"""
+    item = hook.parse_item(
+        '- [ ] 🔀 #460 (你) **等 review** Δ +88/-12 — 最後活動是你 07-12 — "add board tables"'
+    )
+
+    assert item is not None
+    assert item.person == "你"
+    assert item.title == "add board tables"
+    assert item.reason == "最後活動是你 07-12"
+    assert item.action is None
+    assert (item.additions, item.deletions) == (88, 12)
+
+
+def test_parse_item_badges_written_before_delta_still_count():
+    """badge 與 Δ 的相對順序寫反（手改常見）不該讓 badge 靜默消失。"""
+    item = hook.parse_item('- [ ] 🔀 #714 **CI 紅** 💤 Δ +5/-1 — "t"')
+
+    assert item is not None
+    assert item.stale is True
+    assert (item.additions, item.deletions) == (5, 1)
+
+
+def test_parse_item_new_format_judgment_mentioning_arrow_command_is_not_legacy():
+    """`_LEGACY_ACTION_RE` 曾經對整個 tail 做無邊界 `search()`——新格式的判斷句只要
+    提到 `→ \\`command\\`` 這種措辭（引用某個 maigo 命令很常見），就會被誤判成舊格式，
+    title 平白消失。legacy 偵測必須錨定在「title 之前的字串是否真的以此收尾」，
+    而不是整行掃描。"""
+    item = hook.parse_item(
+        '- [ ] 🐛 #9101 (alice) **待 triage** — "CLI crash" '
+        "— 之前建議 → `/maigo:review 123` 但user拒絕"
+    )
+
+    assert item is not None
+    assert item.title_ok is True
+    assert item.title == "CLI crash"
+    assert item.reason == "之前建議 → `/maigo:review 123` 但user拒絕"
+    assert item.action is None
+
+
+def test_parse_item_missing_title_separator_with_trailing_quote_fails_loudly():
+    """新舊格式共用 `_consume_leading_title`：使用者漏打 title 與判斷句之間的分隔
+    符，且判斷句恰好以孤立引號收尾時，最右邊的引號本來會被誤認成 title 的收尾
+    引號，把判斷句整段靜默黏進 title（`title_ok` 仍為 `True`，沒有任何警告）。
+    現在必須大聲失敗，不能靜默腐蝕資料。"""
+    item = hook.parse_item(
+        '- [ ] 🐛 #1 (alice) **READY** — "real title"忘記加分隔符，判斷句以引號結尾"'
+    )
+
+    assert item is not None
+    assert item.title_ok is False
+    assert item.title == ""
+
+
+def test_parse_item_missing_separator_with_paired_stray_quotes_fails_loudly():
+    """同一個「漏打分隔符」壞法的另一種形狀：舊版靠「跳過的引號數是奇是偶」判斷
+    收尾引號合不合法，這裡漏打分隔符後的殘句恰好含**一組成對**引號（`他說 "先
+    別動"`，偶數），parity 檢查完全抓不到，會把整段判斷句連著兩個引號一起黏進
+    title。分隔符必須是強制的，不是猜出來的——這裡也要 `title_ok=False`。"""
+    item = hook.parse_item(
+        '- [ ] 🔀 #6 **有衝突** Δ +1/-1 — "Real Title" 他說 "先別動"'
+    )
+
+    assert item is not None
+    assert item.title_ok is False
+    assert item.title == ""
+
+
+def test_parse_item_new_format_judgment_ending_in_arrow_command_keeps_full_reason():
+    """`_TRAILING_ACTION_RE` 曾經對所有格式無條件套用——新格式的判斷句就算恰好
+    以 `→ \\`command\\`` **收尾**（不像上一條那樣後面還有文字），也只是自由文字引
+    用了某個 maigo 命令，不是舊格式的 action 欄位，不該被腰斬掉。"""
+    item = hook.parse_item(
+        '- [ ] 🔀 #11 **有衝突** Δ +1/-1 — "Real Title" — 之後跑 → `/maigo:review 123`'
+    )
+
+    assert item is not None
+    assert item.title_ok is True
+    assert item.title == "Real Title"
+    assert item.reason == "之後跑 → `/maigo:review 123`"
+    assert item.action is None
+
+
+def test_parse_item_line_grammar_reference_cases_stay_correct():
+    """釘住行文法的一批代表性形狀，逐條核對斷言值：note-only reason、判斷句提到
+    別行的 Δ、embedded quote title、判斷句裡的裸 `📄`、以及三種舊格式（純
+    action／純 action 無 artifact／action ＋ artifact 都有）。任何一條壞掉都代表
+    上面兩個修復動到了不該動的地方。"""
+    with_own_dashed_quote = hook.parse_item(
+        '- [ ] 🔀 #1 **CI 紅** Δ +5/-2 — "Real Title" — 使用者說—"先別動" 要不要照做'
+    )
+    assert with_own_dashed_quote is not None
+    assert with_own_dashed_quote.title == "Real Title"
+    assert with_own_dashed_quote.reason == '使用者說—"先別動" 要不要照做'
+
+    other_items_delta = hook.parse_item(
+        '- [ ] 🐛 #2 (alice) **READY** — "Real Title" — 對照 #99 的 Δ+3/-1 決定要不要跟'
+    )
+    assert other_items_delta is not None
+    assert other_items_delta.additions is None
+    assert other_items_delta.deletions is None
+
+    note_only_reason = hook.parse_item(
+        '- [x] 👀 #3 (bob) **APPROVE**（merged 07-12）Δ +143/-52 — "Real Title"'
+    )
+    assert note_only_reason is not None
+    assert (note_only_reason.additions, note_only_reason.deletions) == (143, 52)
+    assert note_only_reason.note == "（merged 07-12）"
+    assert note_only_reason.reason == ""
+
+    note_no_diff = hook.parse_item(
+        '- [ ] 🐛 #4 (eve) **已放棄**（`--drop` 軟刪）— "Real Title"'
+    )
+    assert note_no_diff is not None
+    assert note_no_diff.title == "Real Title"
+
+    embedded_quote_title = hook.parse_item(
+        '- [ ] 🐛 #9 (alice) **READY** — "標題 "內嵌" 結束" — 判斷 "甲" 或 "乙"'
+    )
+    assert embedded_quote_title is not None
+    assert embedded_quote_title.title == '標題 "內嵌" 結束'
+    assert embedded_quote_title.reason == '判斷 "甲" 或 "乙"'
+
+    bare_artifact_emoji_in_judgment = hook.parse_item(
+        '- [ ] 🐛 #12 (alice) **READY** — "Real Title" — 記得看 📄 那份設計稿'
+    )
+    assert bare_artifact_emoji_in_judgment is not None
+    assert bare_artifact_emoji_in_judgment.artifact is None
+
+    legacy_action_only = hook.parse_item(
+        "- [ ] 🔀 #14 (你) **CHANGES_REQUESTED** Δ +286/-74 — reviewer 要改 "
+        '→ `/maigo:address-comments` — "Old Title"'
+    )
+    assert legacy_action_only is not None
+    assert legacy_action_only.title == "Old Title"
+    assert legacy_action_only.action == "/maigo:address-comments"
+    assert legacy_action_only.reason == "reviewer 要改"
+
+    legacy_action_no_diff = hook.parse_item(
+        "- [ ] 🐛 #15 (alice) **READY** — triage 完可接 "
+        '→ `/maigo:take-issue 15` — "Old Title"'
+    )
+    assert legacy_action_no_diff is not None
+    assert legacy_action_no_diff.title == "Old Title"
+    assert legacy_action_no_diff.action == "/maigo:take-issue 15"
+
+    legacy_action_and_artifact = hook.parse_item(
+        "- [x] 👀 #16 (carol) **↩︎ 回你的球** Δ +91/-38 — 又推了 commit "
+        '→ `/maigo:review 16` 📄 `review-16.md` — "Old Title"'
+    )
+    assert legacy_action_and_artifact is not None
+    assert legacy_action_and_artifact.title == "Old Title"
+    assert legacy_action_and_artifact.action == "/maigo:review 16"
+    assert legacy_action_and_artifact.artifact == "review-16.md"
+    assert legacy_action_and_artifact.reason == "又推了 commit"
+
+
+def test_render_board_keeps_section_headings_as_real_markdown_for_toc():
+    """MkDocs 的 TOC regression 修復：`## ` 這行必須原封不動輸出（讓 MkDocs 發出真
+    正的 `<h2>`），不能被改寫成 `<summary>`——那樣 Material 右側目錄會整個是空的
+    （點 1）。只有表格本體才收進 `<details class="board-section-body">`。"""
+    rendered = hook.render_board(BOARD)
+
+    assert "## 🎯 你的球（2）" in rendered
+    assert "## ⏳ 等別人（1）" in rendered
+    assert "<summary>🎯 你的球（2）</summary>" not in rendered
+    assert "<summary>⏳ 等別人（1）</summary>" not in rendered
+    assert 'class="board-section-body"' in rendered
+
+
 def test_render_board_renders_stale_badge():
     board = (
         "# Work Board — Lee-W/maigo\n"
@@ -185,6 +607,7 @@ def test_render_board_renders_archived_section_as_its_own_table():
     rendered = hook.render_board(board)
 
     assert rendered.count('<table class="work-table">') == 2
+    # heading 保留為真正的 `## ` markdown（見 TOC 相關測試），不再被改寫成 summary
     assert "## 🗄️ 已放棄（1）" in rendered
     assert "status-done" in rendered  # 已放棄 => Tier.DONE
 
@@ -192,6 +615,102 @@ def test_render_board_renders_archived_section_as_its_own_table():
 def test_malformed_line_is_left_untouched():
     malformed = "- [ ] 這是使用者自訂備註"
     assert malformed in hook.render_board(malformed)
+
+
+def test_render_board_action_cell_uses_next_action_for_status_plus_target():
+    """動作欄由 `next_action_for_status()` ＋ item id 組出可複製命令（點 C）。"""
+    rendered = hook.render_board(BOARD)
+
+    assert (
+        'data-copy-command="/maigo:take-issue 123">/maigo:take-issue 123</button>'
+        in rendered
+    )
+
+
+def test_render_board_action_cell_blank_when_no_next_action():
+    """`NEEDS_CHANGES`（WAITING）／`等 review`（AWAITING_REVIEW）都沒有預設
+    下一步——動作欄留白（點 C）。"""
+    rendered = hook.render_board(BOARD)
+
+    assert rendered.count('<td class="action-cell"></td>') == 2
+
+
+def test_render_board_moves_author_diff_status_artifact_into_row_detail():
+    """作者/Δ/狀態詞原文/📄 產物移入每列的 ⌄ 展開區，不再各自成欄（點 C）。"""
+    rendered = hook.render_board(BOARD)
+
+    assert (
+        '<div class="row-detail-item"><span class="work-author">bob</span></div>'
+        in rendered
+    )
+    assert (
+        '<div class="row-detail-item"><span class="diff-add">+120</span> '
+        '<span class="diff-delete">−45</span></div>' in rendered
+    )
+    assert (
+        '<div class="row-detail-item"><span class="work-status status-wait">'
+        "NEEDS_CHANGES</span></div>" in rendered
+    )
+    assert (
+        '<div class="row-detail-item"><a class="artifact-link" '
+        'href="../review-9/">📄 review-9.md</a></div>' in rendered
+    )
+
+
+def test_render_board_keeps_status_note_in_detail_and_judgment_in_ball_cell():
+    board = (
+        "# Work Board — Lee-W/maigo\n"
+        "## ⏳ 等別人（1）\n"
+        "- [ ] 🐛 #9103 (erin) **NEEDS_INFO**（已請補完整 log） "
+        '— "Hook exits" — 能不能穩定重現\n'
+    )
+
+    rendered = hook.render_board(board)
+
+    assert '<div class="work-reason">能不能穩定重現</div>' in rendered
+    assert (
+        '<span class="work-status status-wait">NEEDS_INFO</span> '
+        '<span class="work-note">（已請補完整 log）</span>' in rendered
+    )
+    assert '<div class="work-reason">（已請補完整 log）' not in rendered
+
+
+def test_render_board_tier_shown_as_row_left_border_class_not_column():
+    """tier 改用列左側色條（tr class）呈現，不再獨立成欄（點 C）。"""
+    rendered = hook.render_board(BOARD)
+
+    assert "tier-row status-act" in rendered  # READY => Tier.ACT
+    assert '<td class="status-cell">' not in rendered
+
+
+def test_render_board_no_muted_placeholder_dashes_for_empty_values():
+    """空值（無 Δ、無判斷句）不再印 `—` 佔位（點 C 最後一項）。"""
+    board = (
+        "# Work Board — Lee-W/maigo\n"
+        "## 🎯 你的球（1）\n"
+        '- [ ] 🐛 #501 (carol) **待 triage** — "no diff no reason"\n'
+    )
+
+    rendered = hook.render_board(board)
+
+    assert 'class="muted"' not in rendered
+
+
+def test_render_board_default_open_state_only_target_section_expanded():
+    """只有 🎯 你的球預設展開；其餘分區（如 ⏳）預設收合（點 D）。"""
+    rendered = hook.render_board(BOARD)
+
+    target_index = rendered.index("## 🎯 你的球（2）")
+    target_details = rendered.index('<details class="board-section-body"', target_index)
+    assert rendered[target_details : target_details + 60].startswith(
+        '<details class="board-section-body" open markdown="1">'
+    )
+
+    wait_index = rendered.index("## ⏳ 等別人（1）")
+    wait_details = rendered.index('<details class="board-section-body"', wait_index)
+    assert rendered[wait_details : wait_details + 60].startswith(
+        '<details class="board-section-body" markdown="1">'
+    )
 
 
 def test_render_board_explains_checkbox_is_orthogonal_to_tiers():

--- a/tests/test_board_state.py
+++ b/tests/test_board_state.py
@@ -498,6 +498,27 @@ class TestTierTotality:
     def test_unknown_status_returns_none(self):
         assert bs.tier_for_status("這不是一個合法狀態詞") is None
 
+
+class TestNextActionForStatus:
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            pytest.param("READY", "/maigo:take-issue", id="ready-issue"),
+            pytest.param("待 triage", "/maigo:triage-issue", id="pending-triage"),
+            pytest.param(
+                "CHANGES_REQUESTED",
+                "/maigo:address-comments",
+                id="changes-requested",
+            ),
+            pytest.param("待 review", "/maigo:review", id="pending-review"),
+            pytest.param("可合併", None, id="mergeable"),
+            pytest.param("closed", None, id="closed"),
+            pytest.param("這不是一個合法狀態詞", None, id="unknown"),
+        ],
+    )
+    def test_returns_action_for_status(self, status, expected):
+        assert bs.next_action_for_status(status) == expected
+
     def test_allowed_transitions_covers_every_status_and_none(self):
         assert set(bs.ALLOWED_TRANSITIONS) == set(bs.BoardStatus) | {None}
 


### PR DESCRIPTION
Render board sections as collapsible three-column tables with status-derived actions and details on demand. Move titles ahead of optional judgment sentences while preserving legacy row parsing and loud failures for malformed rows. Run MkDocs integration coverage in clean CI environments and upgrade unmodified v7 CSS scaffolds to v8.