### PR TITLE
docs(skills): absorb shared-checkout, re-review and single-observation rules

### DIFF
--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -202,7 +202,7 @@ stopping there: report the branch/compare URL and ask if a PR should be opened.
 
 ## Worktree hygiene (references)
 
-Eleven conventions for worktree lifecycle and git-attribution — sibling-layout
+Fourteen conventions for worktree lifecycle and git-attribution — sibling-layout
 naming, when to open a separate worktree for a pre-existing issue, deferring
 colliding work, batch cleanup safety, squash-merge-aware "already merged"
 checks, and not over-attributing surprising git state (commits/rebases/wrong
@@ -212,6 +212,12 @@ parallel or an unverified delegate report. Details and recipes in
 
 - **Sibling layout** — worktrees live as siblings of the main checkout
   (`<repo>-<topic>`, branch `<topic>`), not nested under a tool's default path.
+- **Start a task in its own worktree from the outset, not midway** — a
+  mid-task switch costs more than staying (untracked files don't follow a
+  branch switch, running agents get interrupted); correct on the *next* task.
+- **`ListAgents` before touching the git index** on a shared checkout — a
+  peer session can be on the same checkout/branch with zero mutual awareness,
+  and `git status` alone won't reveal it.
 - **Pre-existing fix → new worktree off upstream/main**, not folded into the
   current feature branch (proportionality counter-case for trivial diffs).
 - **Colliding work gets deferred** — when approved work overlaps an

--- a/skills/git-workflow/references/worktree-hygiene.md
+++ b/skills/git-workflow/references/worktree-hygiene.md
@@ -208,6 +208,52 @@ upstream/main..HEAD` or equivalent) — don't assume a stable commit hash
 across the session, and don't assume a reflog-visible rewrite is
 self-inflicted just because no stash was involved.
 
+## Start a task in its own worktree from the outset, and detect peer sessions with `ListAgents` before writing
+
+Two conventions that trace back to the same root cause — a shared main
+checkout can have another interactive session on it with zero mutual
+awareness — at opposite ends of a task's lifecycle: before starting, and
+before every write.
+
+**Open the worktree before the first tool call, not partway through.** Start
+a new task with `git worktree add <workspaces-root>/<repo>-<topic> -b <topic>
+upstream/main` immediately, rather than beginning work on the shared main
+checkout and moving into a worktree only once a collision surfaces. If a task
+is already partway done on the shared checkout when this is noticed, **stay
+there and finish it, then commit** — don't switch mid-task. The switch costs
+more than the risk it avoids: untracked files don't follow a branch switch,
+an already-running agent has to be interrupted, and partial work gets
+discarded and redone. Apply the worktree-from-the-outset rule starting with
+the *next* task, not the current one.
+
+**Before touching the git index (`git add`) or committing on a shared
+checkout, run `ListAgents`** to rule out an active peer session on the same
+checkout/branch. Two interactive sessions can be open on the same main
+checkout, on the same branch, with no way to discover each other except by
+proactively checking — `git status` only shows current file-level effects,
+not a peer session's intentions.
+
+**Treat every git command's output as a snapshot of right now, not a fact
+carried forward across turns or tool calls.** Concretely:
+
+- Commit SHAs quoted earlier in the conversation can go stale mid-conversation
+  if the branch gets rebased onto a newer upstream outside this session's
+  knowledge — re-run `git log` rather than reusing an earlier-turn SHA.
+- Before reverting or "fixing" something that looks inconsistent (a comment
+  that doesn't match what's expected, a change not remembered making), check
+  whether it was an **intentional manual edit** by a peer session first —
+  don't silently overwrite it while fixing something unrelated.
+- Before treating uncommitted-looking content as lost, check `git branch
+  --list` and `git stash list` — it may already be safely committed on a
+  peer session's own separate branch, not lost at all.
+
+**Concrete incident** (same session, two collisions back to back): a peer
+session read this session's uncommitted diff, mistook it for its own work to
+continue, verified it, and pushed the branch to `origin`; both sessions then
+repeatedly ran `git add`/`git reset` trying to get `prek` to see the same
+untracked files, churning the index back and forth between them. Neither side
+had run `ListAgents` before touching the index.
+
 ## Reverify branch and status before any write action
 
 A shared workspace (multiple parallel sessions/terminals against the same

--- a/skills/harness-discipline/SKILL.md
+++ b/skills/harness-discipline/SKILL.md
@@ -48,8 +48,9 @@ description: This skill should be used when the maigo orchestrator, running in t
 - 要填任何型號／參數／欄位名／旗標，必須有本次 session 內的實據（tool schema、官方
   文件、實跑輸出）；三者都查不到 → 標「未確認」，絕不憑印象編造。
 - **證據必須獨立於嫌疑來源**：斷言資料狀態要先查 git 歷史、判監控工具要取帶外真相、
-  分析自產 log 要用結構化欄位而非 substring、定罪某次改動要跑對照組——七個具體案例
-  見 [`references/evidence-discipline.md`](https://github.com/Lee-W/maigo/blob/main/skills/harness-discipline/references/evidence-discipline.md)。
+  分析自產 log 要用結構化欄位而非 substring、定罪某次改動要跑對照組、單點觀測不能
+  當全稱結論（換一個會改變結果的觀測點來隔離）——八個具體案例見
+  [`references/evidence-discipline.md`](https://github.com/Lee-W/maigo/blob/main/skills/harness-discipline/references/evidence-discipline.md)。
 
 ### docs-only 批次的例外
 

--- a/skills/harness-discipline/references/evidence-discipline.md
+++ b/skills/harness-discipline/references/evidence-discipline.md
@@ -1,7 +1,7 @@
 # Harness Discipline — Evidence Discipline
 
 Loaded on demand by [`skills/harness-discipline/SKILL.md`](https://github.com/Lee-W/maigo/blob/main/skills/harness-discipline/SKILL.md) —
-七個具體案例，共同主題是**證據必須獨立於嫌疑來源**：不能拿被懷疑的來源自己的輸出、
+八個具體案例，共同主題是**證據必須獨立於嫌疑來源**：不能拿被懷疑的來源自己的輸出、
 或自己的推測，來證明那個來源／推測是對的。Read this file when 你要斷言資料狀態、
 判斷一個工具/log 是否可信、或要定罪某次改動造成的錯誤之前。
 
@@ -186,3 +186,75 @@ payload log 證明上游根本沒 fire 該事件，那才是帶外證據。）
   對照它的執行區間再下結論；同時把這視為「該 agent 的其餘自述也需獨立驗證」的
   訊號——產出者不驗自己，改派 fresh-context 驗證者複核。
 - 與第 1 節同源：那條約束自己別把推測寫成事實，這條約束別採信別人的推測。
+
+---
+
+## 8. 單點觀測不足以支撐全稱結論——換一個會改變結果的觀測點來隔離
+
+單一觀察點（一次建構成功、一次抽樣比對、一次 mutation 全綠）常被寫成全稱主張
+（「一定可以」、「完全沒有交集」、「這樣就測到了」），但單點觀測只排除了「這一側」，
+沒有排除「另一側」。判準：**換一個確實會改變結果的觀測點，看結論是否還成立**——
+若換了之後結論翻轉，代表原本的單點觀測本來就沒有區辨力。
+
+**Mutation canary 全綠有三種相反成因**，修法互相衝突，所以「全綠」本身不是結論，是
+待分類的訊號：(1) 情境無區辨力——另一條路徑也會產生同樣的觀測值；(2) 斷言是套套邏輯
+——沒有真的觀測到被測行為；(3) 該 mutation 觸及的分支根本不在任何測試範圍內。第 3
+種最容易被誤判成「驗證通過」（因為指令 exit 0），也容易被反向誤判成「新斷言無效」。
+隔離方法：換一個**確實會改變被測分支輸出**的 mutation 再跑一次；若那個轉紅，原
+mutation 無感就屬第 3 種——原斷言有效，只是打在別的分支上。
+
+實例（apache/airflow backfill partition preview）：`LimitedItemsList` 加
+`orientation` prop 時，指定的 mutation 是把新加的 `data-testid` 從
+`isVertical ? "…" : undefined` 改回無條件字串。跑下去五個測試檔全綠——因為該 gate
+只影響 horizontal 分支，而 4 個 horizontal call site 從來沒有任何測試斷言過「truncate
+到剩餘恰 1 筆」的 DOM。改用**反轉邏輯**的 mutation（`isVertical ? undefined : "…"`）
+立刻轉紅，證明新斷言有效；「字面 mutation 無感」本身成為「該路徑無覆蓋」的證據，被當
+發現回報，而不是被吞掉——若那個覆蓋洞落在 PR 之前就存在、本次未改變的行為上，正解是
+回報並判定不在本 PR scope，不是補測試去填洞。
+
+**第 1 種（情境無區辨力）的修法**：設計「只有被測分支能達成」的場景——通常是讓
+**另一條路徑先跑完、且拿不到值**，逼結果只能由被測分支補上。這句是可獨立套用的
+原則，不限於 React／`reset()`：後端的快取 fallback、API 預設值等任何「多條路徑會
+收斂到同一觀測值」的情境，通常也適用同一個設計動作。下面的實例示範這個原則的具體落地。
+
+實例（apache/airflow PR #71393）：`TriggerDAGForm.tsx` 有兩處寫
+`partitionKey: suggestedPartitionKey ?? undefined`——一處在 `useForm` 的
+`defaultValues`，一處在 `prefillConfig && open` 的 `reset()` effect。為後者寫的測試，
+canary 把 effect 那處改回 `partitionKey: undefined`，8 個測試仍全綠——因為
+react-hook-form 的 `reset()` 遇到 `undefined` 會 fall back 到 mount 時的
+`defaultValues`，而 `defaultValues` 已經是同一個值，兩條路徑的觀測結果完全相同。修法
+是把值改成「mount 之後才到達」：先 render 無建議值（`defaultValues` 因此捕捉到
+`undefined`），再 rerender 帶建議值，只有 effect 能補上；canary 立刻轉紅，且這個場景
+同時也是真實情境（API 查詢在首次 render 後才 resolve），不是為了測試硬造的。
+
+**單點觀測寫成全稱／否定式全稱宣稱，一樣是同型錯誤**，只是發生在交辦與審查而非測試：
+
+- 實作者測到 `OpenAIEmbedding(model="nomic-embed-text")` 建構失敗，寫成「embedding
+  不可用、LLM 可用」；實際 `OpenAI(model="llama3").chat()` 一樣會炸，只是延後到首次
+  呼叫才觸發——建構期驗證與呼叫期驗證是不同的觀測點，兩次抽樣剛好落在同一側，不構成
+  全稱結論。
+- 實作者測到「建構成功」，寫成「accepts any model name string」——同樣是把單點觀測
+  當全稱。
+- **審查者本人也會犯**：一份文件審查中，審查者做了兩個單點 membership 檢查
+  （`gpt-4o` 不在 embedding 清單、`text-embedding-3-small` 不在 LLM 清單），據此宣告
+  「兩份清單完全沒有交集」；實際交集有 `ada`/`babbage`/`curie`/`davinci` 四個舊名稱，
+  它自承「沒有真的算過完整交集」。實作者事後實跑才推翻這個宣稱。
+
+**具體做法**：
+
+- 要回答「這樣就可用／全部情況都是這樣／兩者完全沒有交集」，先問「我手上的觀測點是不是
+  剛好只覆蓋了一側？換一個會改變結果的觀測點會怎樣？」——真的換一個試，不要用同側再測
+  一次來壯膽。
+- 驗「某設定可不可用」要測到**實際使用那一步**（`.chat()`、真的送出、真的跑一次
+  mutation 後的斷言結果），不是只測建構/初始化成功。
+- 要回答「值域有哪些／某值存不存在／兩集合有無交集」，就真的算一次完整集合，不要用
+  兩三個抽樣點推論。
+- 否定式全稱（never / no way to / 完全沒有）最難證，通常要把主句收斂到與證據同範圍——
+  證據只到 membership 抽樣，就只能寫「這幾個抽樣值沒有交集」，不能寫「完全沒有交集」。
+- **審查者的結論同樣要被獨立重跑**——不要因為是審查者說的就照抄；本篇兩個實例都是靠
+  「有沒有換一個會翻盤的觀測點」被抓到的。
+
+Related: mutation-test 作為修法驗證證據的另一半流程（暫時拆掉修法本體 → 測試須轉紅 →
+復原）在 [`skills/strict-review/SKILL.md`](https://github.com/Lee-W/maigo/blob/main/skills/strict-review/SKILL.md)
+的「Mutation test 作為修法驗證證據」段——那條講「怎麼證明修法有守住」，這條講「canary
+全綠時怎麼判斷成因」，兩者互補但不重複。

--- a/skills/strict-review/SKILL.md
+++ b/skills/strict-review/SKILL.md
@@ -153,8 +153,9 @@ Walk through the previous round's must-fix and evidence-pending **one by one**.
 
 When new commits or a new maintainer review arrive on a PR **already
 reviewed before**, do a delta re-review against the stored report rather
-than reviewing from scratch — mechanics and the rebase-range pitfall are in
-`references/review-modes.md`.
+than reviewing from scratch — the two-step ancestor+date check, the
+rebase-range pitfall, and `isResolved` reliability (see below) are in
+`references/review-modes.md` and `references/review-judgment.md`.
 
 **Mutation test 作為修法驗證證據**：光看「新增的斷言轉綠」不夠——測試可能本來就不會失敗，
 或斷言弱到修法被拆掉也不會紅（安慰劑測試）。要求：暫時拆掉修法本體 → 對應測試必須轉紅
@@ -225,8 +226,9 @@ details and recipes in `references/design-integrity.md`:
 
 ## Review judgment: when NOT to flag (references)
 
-Twenty principles for calibrating whether a finding is a real must-fix and how
-much change a comment warrants; details in `references/review-judgment.md`:
+Twenty-three principles for calibrating whether a finding is a real must-fix
+and how much change a comment warrants; details in
+`references/review-judgment.md`:
 
 - **Verify repo config first** — grep linter config + sibling files before flagging a PEP / textbook rule.
 - **Don't escalate coverage gap to correctness bug** — verify reachability + not-by-design (and blast radius — a removed guard isn't automatically must-fix) before calling it a bug.
@@ -249,6 +251,7 @@ much change a comment warrants; details in `references/review-judgment.md`:
 - **Verify a mechanism claim empirically** — write a small isolated repro before publishing a "why this works/breaks" explanation.
 - **Trace the introducing commit before reverting a shared signature** — a type error at a changed signature's use site is usually an incomplete rollout, not a wrong change.
 - **Trace the reconciliation/self-heal loop fully before characterizing a bug's severity** — a mismatch that self-corrects within one cleanup cycle is not the same severity as one that repeats forever; find the actual consumer/cleanup loop before writing the severity language.
+- **Don't trust review-thread `isResolved` in either direction** — a resolved thread can be an empty self-resolve, an open thread can already be fixed; read the thread then verify against code before drawing either conclusion.
 
 Read `references/review-judgment.md` when deciding whether to flag and how large to make the change.
 

--- a/skills/strict-review/references/review-judgment.md
+++ b/skills/strict-review/references/review-judgment.md
@@ -499,6 +499,64 @@ policy produces the wrong call for one of them).
 
 ---
 
+## 23. Don't trust review-thread `isResolved` in either direction — read the thread, then verify against code
+
+`isResolved` on a GitHub review thread is a weak signal **both ways**. It
+cannot be treated as evidence that a comment was addressed, and it cannot be
+treated as evidence that it wasn't:
+
+- An author can resolve their own thread with no code change and no comment
+  — resolved-count going up doesn't mean anything got fixed.
+- Code can be fixed without anyone clicking "resolve" — an open thread can
+  already be moot.
+
+The only reliable method: pull the thread's actual content (GraphQL, since
+REST lacks `isResolved`), read what the commenter asked for, then check the
+current code to see whether it was actually done. The resolved/unresolved
+count only decides which threads to look at first — it is never the
+conclusion.
+
+**Case studies** (apache/airflow):
+
+*Resolved but with nothing behind it*
+
+- **PR #69757** — `resolved=38 / unresolved=2` looked healthy, but a reviewer
+  pointed out directly in the thread that the resolution was a no-op:
+  nothing had changed, and no justification had been given for leaving the
+  code as-is. At least one of those 38 "resolved" threads was an empty
+  self-resolve. An earlier pass had read "40/40 resolved" as a positive
+  signal and been misled by it.
+- **PR #58543** — all 14 threads were self-resolved by the PR's own author;
+  the two people who had raised the objections (one against the state model,
+  one against an `isinstance` special-case) never came back to confirm. One
+  of them had been reviewing an accidentally-reverted stale version at the
+  time.
+
+*Unresolved but already fixed*
+
+- **PR #68778** — `scheduler_job_runner.py` gained a design-intent comment
+  and a docstring that adopted the commenter's suggested wording verbatim,
+  but both threads still showed `isResolved:false`.
+- **PR #71074** — new commits addressed a savepoint-rollback comment and a
+  "re-point instead of deleting log rows" comment; checking the code
+  confirmed both were actually handled, yet the threads stayed open.
+- **PR #70302** — all three commenters had replied "Fixed" and the diff
+  matched what they asked for, but GitHub still showed every thread
+  unresolved.
+
+How to apply:
+
+- When giving feedback to an author, separate **technically addressed** from
+  **not replied to / not resolved on GitHub**. The second is a process gap,
+  not a technical one, but a maintainer scanning open threads still sees it
+  as "an open objection" and it can block a merge decision regardless.
+- Never write "N/N resolved, so no outstanding concerns" in a review report
+  — that sentence was wrong on PR #69757.
+- Symmetrically, don't assume an open thread means unfixed — check the code
+  first.
+
+---
+
 ## See also: parallel batch review safety
 
 Read-only discipline for fanning out multiple PRs to parallel reviewers on a

--- a/skills/strict-review/references/review-modes.md
+++ b/skills/strict-review/references/review-modes.md
@@ -64,6 +64,55 @@ Be precise relaying maintainer thread state: "author replied, awaiting
 reviewer re-confirmation" is not the same as "no response" — GitHub's
 `isResolved: false` often just means nobody has clicked Resolve yet.
 
+### Establish the delta with a two-step check — not `gh pr diff`, not a raw commit range
+
+"What changed since the stored report" is **not** any of:
+
+- `gh pr diff <n>` / `gh pr diff --name-only` — that's the **whole PR vs
+  `main`**, not the delta since the report's `<oldSha>`.
+- A pasted GitHub `.../changes/<oldSha>..<newSha>` range — see below, it
+  often carries rebase/merge noise.
+- `git log <old>..<new>` — only meaningful when `<old>` is actually an
+  ancestor of `<new>`.
+
+Two-step check, run before handing a delta re-review to a subagent (put the
+resolved SHAs in the delegation prompt, not the stale ones from the stored
+report):
+
+```bash
+git merge-base --is-ancestor <old_head> <new_head>        # 1. not an ancestor → old..new is unreliable
+git log --format='%h %ad %s' --date=short <old>..<new>    # 2. read the dates
+```
+
+1. **Ancestor check.** After a force-push/rebase, the old head is no longer
+   an ancestor of the new one — `old..new` then lists rebase-rehashed *old*
+   content as if it were new commits.
+2. **Date check.** Any commit dated before the stored report's review date
+   cannot be a response to that review — the cheapest check, and the one most
+   often skipped.
+
+For the real content delta, use `git diff --stat <old> <new>`; an implausibly
+large file count (hundreds+) means the range still contains a `main` merge —
+fall back to reading the actual `git log` commits.
+
+**Case studies** (apache/airflow, three same-session recurrences of this
+mistake):
+
+- **PR #70671** — `gh pr diff` read as the delta led to asserting the author
+  had responded to three must-fix items and possibly changed design
+  direction. `git diff --stat <old> <new>` showed only one new Markdown file
+  (+124 lines); the seven previously-reviewed source files were
+  byte-identical to the head already reviewed.
+- **PR #58543** — `git log old..new` listed 4 "new" commits.
+  `merge-base --is-ancestor` returned NO (the branch had been rebased); one
+  of the 4 had a commit message identical to the old head's tip (same
+  content, rehashed), and 3 of the 4 were dated before the review — only 1
+  was genuinely new.
+- **PR #68778** — a subagent given a stale worktree SHA in its delegation
+  prompt noticed on its own that the head had moved and re-fetched before
+  reviewing — a fallback that caught the mistake, not a substitute for
+  running the two-step check upfront.
+
 ### A `<oldSha>..<newSha>` compare range spanning a rebase is noise
 
 A pasted GitHub `.../changes/<oldSha>..<newSha>` range that spans a


### PR DESCRIPTION
…

These four rules kept being re-learned from the memory layer, where they compete for the ten relevance-ranked slots and load as one-off facts rather than as the conventions they are. They belong where their trigger already fires: worktree and peer-session hygiene alongside the rest of the git workflow, delta and thread-state distrust alongside the review checklist, and "one observation does not settle the question" alongside the evidence rules it generalises.