### PR TITLE
feat(scripts): add a .maigo/ directory catalog

### DIFF
--- a/commands/board.md
+++ b/commands/board.md
@@ -1,6 +1,6 @@
 ---
 description: 讀寫 `.maigo/board.md` Work Board——混合追蹤 issue、自己的 PR、在審的 PR，依單一優先序階梯排進「下一件 / 等別人 / 最近結案」三區，供 nvim 直接開檔閱讀。orchestrator 直跑，不 delegate 五人。
-allowed-tools: Bash(gh api:*), Bash(gh issue view:*), Bash(gh pr view:*), Bash(gh repo view:*), Bash(python3 scripts/board_state.py:*), Read, Write, Edit
+allowed-tools: Bash(gh api:*), Bash(gh issue view:*), Bash(gh pr view:*), Bash(gh repo view:*), Bash(python3 scripts/board_state.py:*), Bash(python3 scripts/board_index.py:*), Read, Write, Edit
 ---
 
 <!-- mkdocs-include-start -->
@@ -25,6 +25,7 @@ Work Board 是跨 session 的工作看板：issue triage / 接工、自己的 PR
 /maigo:board --check <n...> # 標記「我親自處理過」，作為 --learn 訊號
 /maigo:board --uncheck <n...> # 取消「我親自處理過」標記
 /maigo:board --drop <n...>  # 不追了，移進 ✅ 最近結案（狀態詞 已放棄，7 天後跟其他結案行一起清）
+/maigo:board --cross-repo   # 本地刷新照舊，額外產出跨 repo 總索引
 ```
 
 `targets` 可混用裸編號、GitHub issue URL、GitHub PR URL。裸編號以當前 repo 判定；
@@ -115,6 +116,21 @@ orchestrator 逐項抓使用者在 GitHub 的實際處理方式，蒸餾 0-3 條
 `已放棄`，整行移進 `✅ 最近結案`——跟其他結案行共用同一條 7 天老化規則，不再有獨立的
 留痕區。保留原 checkbox 與 `🧠` 狀態；對應細節檔不動，等 7 天老化清除時跟索引行一起刪
 （見 [`skills/work-board` §3 細節檔生命週期](https://github.com/Lee-W/maigo/blob/main/skills/work-board/SKILL.md)）。
+
+### 8. `--cross-repo`
+
+opt-in，預設不開——跨 13 個 repo 掃描比本地刷新慢得多，不該預設每次都跑。
+先照舊完成本地 `.maigo/board.md` 刷新（步驟 1–4），flag 有帶時追加呼叫：
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/board_index.py" [--repo-list ~/.config/maigo/repos.txt]
+```
+
+印出輸出檔 `~/.config/maigo/board-index.md` 的路徑。**不影響本地 `board.md`
+的行文法／upsert 規則**——`board_index.py` 全程唯讀，只讀各 repo 的
+`board.md`、逐字複製 `## 🎯 下一件` 整段，不重寫任何被掃描 repo 的內容，也不
+新增獨立命令（併入這個 flag）。正典規格見
+[`skills/work-board`](https://github.com/Lee-W/maigo/blob/main/skills/work-board/SKILL.md)。
 
 ## 與其他命令的差異
 

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -32,12 +32,14 @@ allowed-tools: Bash(gh --version:*), Bash(gh auth status:*), Bash(python3:*), Ba
 5. **Token usage**（read-only）：讀 `.maigo/token-usage.jsonl`，彙整最近 7 天總量並依角色／model
    分組。只採用 harness 已提供的 foreground subagent metadata；背景 agent、Codex 或舊版 harness
    沒資料時標示 unavailable，不自行估算、不算 error。
-6. **舊固定檔名孤兒檔**（read-only，只列不刪）：`.maigo/` 底下的產物已改成帶識別碼命名
-   （`plan-<id>.md` / `review-rubric-<id>.md` / `triage-rubric-<id>.md` / `pr-comments-<id>.md`），
-   舊固定檔名（`.maigo/plan.md`、`.maigo/review-rubric.md`、`.maigo/triage-rubric.md`、
-   `.maigo/pr-comments.md`）若還存在，代表是升級前留下的孤兒——只列出來，**不自動刪除**，
-   由使用者自己決定要不要清（見
-   [`artifact-ownership`](https://github.com/Lee-W/maigo/blob/main/skills/harness-discipline/references/artifact-ownership.md)）。
+6. **`.maigo/` 頂層型錄**（read-only，只列不刪）：呼叫
+   `scripts/maigo_dir_catalog.py` 掃描 `.maigo/` 頂層 `*.md` 檔，分成四類——
+   已知種類的識別碼命名（`plan-<id>.md` 這類）、已知種類的舊固定檔名
+   （`.maigo/plan.md` 這類，代表升級前留下的孤兒）、已登記的非 artifact 檔
+   （`board.md`）、其餘全部歸為未登記檔案。舊固定檔名與未登記檔案都**只列出來，
+   不自動刪除、不建議刪除哪一個**，由使用者自己決定（見
+   [`artifact-ownership`](https://github.com/Lee-W/maigo/blob/main/skills/harness-discipline/references/artifact-ownership.md)
+   與 [`docs/reference/artifacts.md`](https://github.com/Lee-W/maigo/blob/main/docs/reference/artifacts.md)）。
 
 ## 流程
 
@@ -62,7 +64,8 @@ python3 scripts/retry_log_summary.py
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/token_usage_summary.py" --root "$PWD"
 ```
 
-5. **Orchestrator**：列出 `.maigo/` 底下的舊固定檔名孤兒檔（`ls .maigo/{plan,review-rubric,triage-rubric,pr-comments}.md 2>/dev/null` 存在就列，不存在就跳過），只回報路徑，不刪除。
+5. **Orchestrator**：跑 `python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/maigo_dir_catalog.py"` 拿到
+   `.maigo/` 頂層四類分類，只回報路徑，不刪除、不建議刪除哪一個。
 6. **Orchestrator**：
    - 彙整報告。
    - 針對缺失項給予具體的「改進」建議（不使用「優化」）。
@@ -96,6 +99,10 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/token_usage_summary.py" --root "$PWD"
 
 ## 📦 舊產物孤兒檔（升級前的固定檔名，只列不刪）
 - <`.maigo/plan.md` 等舊檔名清單，或「無孤兒檔」>
+
+## ❓ 未登記檔案（不屬於任何已知 artifact 種類，只列不動）
+- <不在 `_KNOWN_KINDS` 識別碼命名 / 舊固定檔名 / 已登記非 artifact 檔（`board.md`）
+  三類白名單內的頂層 `.maigo/*.md` 檔清單，或「無未登記檔案」——不建議刪除哪一個>
 
 ## 📢 建議
 - ...

--- a/commands/go.md
+++ b/commands/go.md
@@ -14,6 +14,7 @@ description: MyGO!!!!! 跑一遍——樂奈先看、燈寫計畫、愛音動手
 
 ```
 /maigo:go <任務描述>
+/maigo:go --worktree <任務描述>   # 在獨立的 sibling worktree 裡跑整趟流程
 ```
 
 ## 流程
@@ -22,6 +23,26 @@ description: MyGO!!!!! 跑一遍——樂奈先看、燈寫計畫、愛音動手
 🐱 樂奈探索 → 🩵 燈寫 plan → 使用者確認 → 🎀 愛音實作 → 🟡 爽世 review → 🟣 立希驗證。
 
 審查與驗證為**順序**進行（先 🟡 爽世擋，通過後才跑 🟣 立希）。
+
+## `--worktree`（opt-in，預設不開）
+
+帶這個旗標時，在 🐱 樂奈開始之前，orchestrator 親自跑：
+
+```bash
+git fetch <remote>
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/worktree_path.py" --repo <name> --topic "<任務描述>"
+git worktree add -b <branch> <path> <remote>/<default-branch>
+```
+
+`<remote>` 判定：先試 `upstream`，否則退回 `origin`。之後每個 delegate 的 prompt
+都要帶上這個 `path` 當 cwd（見
+[`skills/teammate-flow`](https://github.com/Lee-W/maigo/blob/main/skills/teammate-flow/SKILL.md)
+的 cwd 交辦紀律）。
+
+收尾（🟣 立希全綠、commit 草擬完）時印出這個 worktree 的路徑與 branch，明講
+「留在原地，等 PR merge 後可用 `/maigo:repo-audit` 看到清理建議」——**不在這裡
+自動移除**。細節、`.maigo/` 歸屬規則見
+[`skills/git-workflow/references/worktree-automation.md`](https://github.com/Lee-W/maigo/blob/main/skills/git-workflow/references/worktree-automation.md)。
 
 ## 失敗處理
 

--- a/commands/repo-audit.md
+++ b/commands/repo-audit.md
@@ -1,6 +1,6 @@
 ---
-description: repo 自身內部健診（read-only orchestrator 主持）——掃已合併可刪的 branch、未關 PR、TODO/FIXME 積壓、skill 健診（孤兒 / 重疊候選 / 指向失效），彙整成可複製的處置 checklist，不執行任何寫入。🌑 Mortis 一句結算。不 delegate 五人，orchestrator 直跑。
-allowed-tools: Bash(git branch --merged:*), Bash(gh pr list:*), Bash(grep:*), Read
+description: repo 自身內部健診（read-only orchestrator 主持）——掃已合併可刪的 branch、未關 PR、TODO/FIXME 積壓、skill 健診（孤兒 / 重疊候選 / 指向失效）、已合併可清的 sibling worktree，彙整成可複製的處置 checklist，不執行任何寫入。🌑 Mortis 一句結算。不 delegate 五人，orchestrator 直跑。
+allowed-tools: Bash(git branch --merged:*), Bash(gh pr list:*), Bash(grep:*), Bash(git worktree list:*), Bash(gh search prs:*), Read
 ---
 
 <!-- mkdocs-include-start -->
@@ -20,7 +20,7 @@ read-only 內部健診——不刪 branch、不關 PR、不改 code。
 
 無參數。對當前所在的 git repo 執行。
 
-## 四個資料源（全 read-only）
+## 五個資料源（全 read-only）
 
 ### A. 已合併可刪的 branch
 
@@ -72,6 +72,24 @@ orchestrator 讀 `skills/*/SKILL.md`（不開新 agent），三類檢查：
 → **三類都只列出，不合併、不刪除、不改指向**——advisory，判斷與執行留給使用者或後續
 [`/maigo:crystallize`](https://github.com/Lee-W/maigo/blob/main/commands/crystallize.md)。
 
+### E. 已合併可清的 sibling worktree
+
+```bash
+git worktree list --porcelain
+```
+
+列出所有 linked worktree（不能用「目錄名長得像 `<repo>-*`」去猜——`ring` /
+`ring-codex` 是兩個各自獨立的 clone，不是彼此的 worktree，必須用 `git worktree
+list --porcelain` 這種權威來源）。對每個 worktree 的 branch 名，比照 A 段既有的
+「已合併」判斷方法（squash-merge 場景用 `gh search prs` 而非 `git branch
+--merged`，見
+[`skills/git-workflow/references/worktree-hygiene.md`](https://github.com/Lee-W/maigo/blob/main/skills/git-workflow/references/worktree-hygiene.md)）
+判斷是否已合併，命中就把 `git worktree remove <path>` + `git branch -D
+<branch>` 加進處置 checklist。
+
+→ **列出，不執行。** 這是 repo-audit 既有的「單一 repo、cwd 視角」報告——跟
+Group F 的跨 repo 總索引是不同東西，不在這裡順手加跨 repo 掃描。
+
 ## 輸出結構
 
 各段有發現時，彙整成**單一 fenced code block** 的處置 checklist：
@@ -96,9 +114,13 @@ gh pr view <number>
 # 重疊候選：<skill A> / <skill B> — <一句理由>
 # 指向失效：<skill>/SKILL.md → `<path>` 不存在
 # → 合併 / 退役 / 修指向，交你或 /maigo:crystallize 判斷
+
+## E. 已合併可清的 sibling worktree
+git worktree remove <path>
+git branch -D <branch-name>
 ```
 
-各段無發現則**省略該段**；四段全空則省略整個 checklist。
+各段無發現則**省略該段**；五段全空則省略整個 checklist。
 **範例 code block 內不寫絕對路徑**——以相對路徑或 `~/` 表示。
 
 ## 結算
@@ -115,7 +137,7 @@ gh pr view <number>
 - **完全 read-only**：不刪 branch、不關 PR、不改 code；處置只輸出文字，不執行。
 - **不 delegate 五人**：orchestrator 直接執行 git / gh / grep 指令 + 讀 SKILL.md 判斷，彙整輸出。
 - **任一指令失敗 → 跳過該段 + Mortis 1 句告知，不中斷整輪**：
-  - `gh` 失敗（未安裝 / 未登入）→ 跳過 B 段
+  - `gh` 失敗（未安裝 / 未登入）→ 跳過 B 段（判斷 E 段合併狀態用的 `gh search prs` 同樣受影響，跳過即可，不擋 E 段其餘列表輸出）
   - `git` / `grep` 失敗 → 跳過對應段
 - **D 段是判斷型 advisory**：孤兒 / 重疊 / 指向失效三類都只列出候選，不代使用者拍板合併或刪除。
 - **開場**：🌙 Doloris 帶入（鋪陳語氣，見 [`skills/narration`](https://github.com/Lee-W/maigo/blob/main/skills/narration/SKILL.md)）。

--- a/commands/review.md
+++ b/commands/review.md
@@ -146,7 +146,29 @@ GraphQL url 補丁）、Conversation comments（`gh pr view --json comments`）�
 單一 PR / branch / range（預設）輸出 Context / Rubric / Verdict / Verification / Bottom line
 五段；batch 內最後一個 PR 跑完後把「Queue 還剩...」那行換成 roll-up；`--bilingual` 或
 repo-detect 觸發時最終 report 前加 Taiwanese Mandarin 快結 + horizontal rule 再接英文 detail。
-三種版型的完整骨架見 `skills/strict-review/references/review-templates.md`「輸出」。
+三種版型的完整骨架見
+[`skills/strict-review/references/review-templates.md`](https://github.com/Lee-W/maigo/blob/main/skills/strict-review/references/review-templates.md)「輸出」——
+這份骨架同時是要逐字寫入的檔案內容，兩者不分開維護。
+
+印出五段報告之前，orchestrator 先呼叫：
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/artifact_path.py" review \
+    --topic "Review: <PR title / branch / range>"
+```
+
+取得落檔路徑（歸屬規則見
+[`artifact-ownership`](https://github.com/Lee-W/maigo/blob/main/skills/harness-discipline/references/artifact-ownership.md)）：
+
+- `status: conflict`（exit 3）→ 依 artifact-ownership 規則 3，把 `conflict_owner:` 與
+  `suggest:` 呈現給使用者，不擅自覆寫既有檔案，等使用者決定要不要採用 `suggest:` 路徑
+- 其餘 status → 把完整的五段（或 `--bilingual` 版、或 batch roll-up 版）報告內容
+  **逐字寫入**該路徑的檔案，再照舊在對話裡印一份——檔案是真相、對話是即時可讀，
+  兩者都要，不是二選一
+
+**多 PR batch**：每顆 PR 各自呼叫一次 `artifact_path.py review --topic "Review: <該 PR 的
+title>"`（H1 各自不同），各自落一份 `review-<id>.md`——GitHub PR 有 `--url` 天然走
+`resolve_identifier()` 第 1 級，identifier 各自不同，不會互相覆寫，不需要額外機制。
 
 ## Work Board 回寫
 
@@ -161,7 +183,8 @@ GitHub PR review 每跑完一顆並輸出 report 後，依
 - 已在 GitHub 回覆 / approve，且之後無新活動 → 👀 行進 ⏳ 等別人，狀態詞寫實際 verdict
   （`BLOCKED` / `NEEDS_CHANGES` / `APPROVE_WITH_NITS` / `APPROVE`）
 - merged / closed → 👀 行進 ✅ 最近結案
-- 這份 `review-<n>.md` 產物路徑寫進對應細節檔（`.maigo/i/<slug>.md`，見
+- 上面「## 輸出」段呼叫 `artifact_path.py review` 拿到的 `path:`（即這份
+  `review-<id>.md` 產物的實際路徑）寫進對應細節檔（`.maigo/i/<slug>.md`，見
   [`skills/work-board` §1a](https://github.com/Lee-W/maigo/blob/main/skills/work-board/SKILL.md)）
   的 `## 筆記` 區，一行裸相對路徑連結——不再寫進索引行
 

--- a/commands/take-issue.md
+++ b/commands/take-issue.md
@@ -14,7 +14,28 @@ allowed-tools: Bash(gh issue view:*), Read
 
 ```
 /maigo:take-issue <issue 編號或 URL>
+/maigo:take-issue --worktree <issue 編號或 URL>   # 在獨立的 sibling worktree 裡跑整趟流程
 ```
+
+## `--worktree`（opt-in，預設不開）
+
+帶這個旗標時，在 🐱 樂奈開始之前，orchestrator 親自跑：
+
+```bash
+git fetch <remote>
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/worktree_path.py" --repo <name> --topic "<issue 標題>"
+git worktree add -b <branch> <path> <remote>/<default-branch>
+```
+
+`<remote>` 判定：先試 `upstream`，否則退回 `origin`。之後每個 delegate 的 prompt
+都要帶上這個 `path` 當 cwd（見
+[`skills/teammate-flow`](https://github.com/Lee-W/maigo/blob/main/skills/teammate-flow/SKILL.md)
+的 cwd 交辦紀律）。
+
+收尾（🟣 立希全綠、commit 草擬完）時印出這個 worktree 的路徑與 branch，明講
+「留在原地，等 PR merge 後可用 `/maigo:repo-audit` 看到清理建議」——**不在這裡
+自動移除**。細節、`.maigo/` 歸屬規則見
+[`skills/git-workflow/references/worktree-automation.md`](https://github.com/Lee-W/maigo/blob/main/skills/git-workflow/references/worktree-automation.md)。
 
 ## 流程
 

--- a/docs/reference/artifacts.md
+++ b/docs/reference/artifacts.md
@@ -1,0 +1,46 @@
+# `.maigo/` Artifacts Reference
+
+`.maigo/` 全貌型錄：這個目錄底下有哪些檔、各自的正典（code + skill）是誰、
+生命週期多長。找不到某個 `.maigo/` 檔案該歸哪一類時，先查這頁；機器判斷
+邏輯（哪個檔案屬於哪一類）由 `scripts/maigo_dir_catalog.py` 執行，不是散文
+自己判斷——見 [`/maigo:doctor`](../commands/doctor.md) 的「`.maigo/` 頂層型錄」段。
+
+## 帶識別碼命名的產物（`<kind>-<id>.md`）
+
+| 種類 | 檔名規則 | 誰寫的 | 正典來源 | 生命週期 |
+|------|----------|--------|----------|----------|
+| `plan` | `.maigo/plan-<id>.md` | 🩵 Tomori | `scripts/artifact_path.py` + [artifact-ownership](https://github.com/Lee-W/maigo/blob/main/skills/harness-discipline/references/artifact-ownership.md) | 單次任務的實作計畫，任務結束後仍留存供追溯 |
+| `review-rubric` | `.maigo/review-rubric-<id>.md` | 🩵 Tomori | 同上 | 對照基準，review 全程比對用；review 結束後留存 |
+| `review` | `.maigo/review-<id>.md` | orchestrator（`/maigo:review`） | 同上 | 最終 review 五段報告的逐字檔案版；長期留存供 `grep` / board 細節檔連結 |
+| `triage-rubric` | `.maigo/triage-rubric-<id>.md` | 🩵 Tomori | 同上 | issue triage 的對照基準 |
+| `pr-comments` | `.maigo/pr-comments-<id>.md` | orchestrator（`/maigo:address-comments`） | 同上 | PR 既有 review comment 的抓取與分類結果 |
+
+四種 kind 全部由 `scripts/artifact_path.py` 的 `_KNOWN_KINDS` 單一正典定義，
+`resolve_for_write()` 是唯一對外寫入入口——同一檔名撞到不同主題時回
+`status: conflict`，呼叫端必須先問使用者再決定要不要用建議的候選檔名，
+不擅自覆寫。
+
+## Work Board（`board.md` + `i/<slug>.md`）
+
+| 種類 | 檔名規則 | 誰寫的 | 正典來源 | 生命週期 |
+|------|----------|--------|----------|----------|
+| Work Board 索引 | `.maigo/board.md` | orchestrator（`/maigo:board` / `/maigo:review`） | `scripts/board_state.py` + [work-board skill](../skills/work-board.md) | 跨 session 常駐，不隨單次任務結束而收檔 |
+| Work Board 細節檔 | `.maigo/i/<slug>.md` | 同上 | 同上 | 跟著對應 issue/PR 的追蹤狀態走；孤兒偵測見 `/maigo:board` 既有邏輯 |
+
+board 這條線是全 repo 最佳實踐——code 定正典（`board_state.py`）、skill 鏡射
+人讀版本（`work-board`）、test 守一致（`tests/test_board_state.py`），三方鎖住，
+本頁不重寫它的行文法，只在型錄裡佔一個位置。
+
+## 非 markdown 機器狀態檔
+
+一行帶過，內部用，非 agent 面向格式：`session-head.json`（session 開始時的
+HEAD SHA）、`token-usage.jsonl`（token usage metadata）、
+`test-failures.jsonl` / `soyo-must-fix.jsonl`（retry / failure log）、
+`__titles.json`（內部快取）。
+
+## 舊固定檔名與未登記檔案
+
+升級前留下的舊固定檔名（`.maigo/plan.md` 這類）與不屬於上述任何種類的
+未登記檔案，一律**只列不刪**——正典邏輯見 `scripts/maigo_dir_catalog.py`，
+人讀報告見 [`/maigo:doctor`](../commands/doctor.md)。要不要清由使用者自己
+決定，這份型錄與 doctor 報告都不建議刪除哪一個。

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1,6 +1,6 @@
 # Hooks Reference
 
-Maigo 的 Claude Code plugin 註冊五個 hook，定義在 `hooks/hooks.json`。
+Maigo 的 Claude Code plugin 註冊六個 hook，定義在 `hooks/hooks.json`。
 只要 Claude Code plugin 載入就自動生效，使用者不用設定。
 
 Codex manifest 會用空的 inline hooks 覆蓋這組 Claude Code lifecycle hooks；
@@ -34,8 +34,8 @@ approve。讓 contributor 進到熟悉的 codebase 時，自動拿到該 repo �
 
 不分 project，每次 SessionStart 都跑（在 rule 偵測之前）。maigo 的所有 command
 （go / quick / team / review / address-comments）都把 plan、review rubric、
-pr-comments、retry log 等 artefact 寫進 repo root 的 `.maigo/`，這些絕不該被
-commit。
+review 報告（`review-<id>.md`）、pr-comments、retry log 等 artefact 寫進 repo
+root 的 `.maigo/`，這些絕不該被 commit。
 
 為了不動到 host repo 被追蹤的 `.gitignore`（例如 apache/airflow 的 `.gitignore`
 是上游檔案），hook 改寫該 repo 的 `info/exclude`——路徑用
@@ -153,6 +153,38 @@ PreToolUse 的 `approve` 等於跳過權限系統。這個 hook 沒有資格代�
 ### Fail-open 情況
 
 - input 不是有效 JSON、`tool_input` 不是 object、`prompt` 不是非空字串 → 靜默放行
+
+### Timeout
+
+5 秒上限。純 regex，毫秒級完成。
+
+## PreToolUse — `hooks/legacy_artifact_path_check.py`
+
+匹配 `Write` / `Edit` 兩種工具。擋下寫入 `.maigo/` 底下**舊固定檔名**的產物
+（`plan.md` / `review-rubric.md` / `review.md` / `triage-rubric.md` /
+`pr-comments.md`）——跨 13 個實際安裝 maigo 的 repo 實測，散文說「一律呼叫
+`scripts/artifact_path.py`」的採用率是 0%，這支 hook 改用程式碼擋。
+
+反向判準：`kind` 清單動態組自 `from artifact_path import _KNOWN_KINDS`
+（不重複列一份 kind 清單字面值），regex 錨定 `.maigo/` 目錄下、且必須是
+`<kind>.md`（stem 整個等於某個 kind）——`plan-main.md` 這類已含識別碼的新
+命名、`board.md`、`local-model-dispatch-plan.md`、`.maigo/i/9201.md` 都天然
+不命中，不必特別寫排除規則。
+
+命中時 block，訊息附上正確的 `artifact_path.py` 呼叫指令範例，以及
+[artifact-ownership](https://github.com/Lee-W/maigo/blob/main/skills/harness-discipline/references/artifact-ownership.md)
+規則 4 的提醒。
+
+### 放行為什麼不輸出 decision
+
+同 `delegation_criteria_check.py`：PreToolUse 的 `approve` 等於跳過權限系統，
+這個 hook 沒有資格代替使用者做那個決定，所以只在命中時 `block`，放行一律靜默
+`exit 0`。
+
+### Fail-open 情況
+
+- input 不是有效 JSON、`tool_name` 不是 `Write`/`Edit`、`tool_input` 不是
+  object、`file_path` 不是非空字串 → 靜默放行
 
 ### Timeout
 
@@ -329,6 +361,10 @@ python3 -c "import json,sys; print(json.dumps({'teammate_role':'Soyo','teammate_
 # 模擬 Stop 觸發
 python3 -c "import json,sys; print(json.dumps({'cwd':'/path/to/project'}))" \
   | python3 hooks/verify_completion.py
+
+# 模擬 Write 到舊固定檔名（應該 block）
+python3 -c "import json; print(json.dumps({'tool_name':'Write','tool_input':{'file_path':'.maigo/plan.md'}}))" \
+  | python3 hooks/legacy_artifact_path_check.py
 
 # 模擬 foreground Agent usage metadata
 python3 -c "import json; print(json.dumps({'hook_event_name':'PostToolUse','tool_name':'Agent','session_id':'demo','cwd':'/path/to/project','tool_input':{'subagent_type':'maigo:Soyo'},'tool_response':{'status':'completed','agentId':'agent-1','resolvedModel':'claude-sonnet','usage':{'input_tokens':100,'output_tokens':20}}}))" \

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -22,6 +22,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/legacy_artifact_path_check.py",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/hooks/legacy_artifact_path_check.py
+++ b/hooks/legacy_artifact_path_check.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Maigo PreToolUse hook：擋下寫入 `.maigo/` 底下舊固定檔名的產物。
+
+背景：`scripts/artifact_path.py` 的 `<kind>-<id>.md` 命名規範存在近兩個月，跨
+13 個實際安裝 maigo 的 repo 一查，採用率是 0%——不是規範不好，是散文說「一律
+呼叫 `artifact_path.py`」，但沒有任何東西擋著一個趕時間的 agent 直接
+`Write(".maigo/plan.md", ...)`。這支 hook 就是那個「東西」。
+
+只匹配 `Write` / `Edit` 兩種工具。反向判準：`kind` 清單動態組自
+`from artifact_path import _KNOWN_KINDS`（不重複列一份 kind 清單字面值），
+regex 錨定在 `.maigo/` 目錄下，且必須是這幾個 kind 的**舊固定檔名**
+（`<kind>.md`）——`plan-main.md` 這類已含識別碼的新命名不命中，因為 regex
+要求 `<kind>.md` 前面沒有 `-<id>` 尾巴（stem 必須整個等於某個 kind）。
+
+`board.md`（不在 `_KNOWN_KINDS` 裡）、`local-model-dispatch-plan.md`（stem 不
+等於任何 kind）、`.maigo/i/9201.md`（不在 `.maigo/` 頂層）都天然不命中——白名單式
+反向判準，不必為它們特別寫排除規則（呼應
+`deny-by-default-when-tool-generates-paths` 記憶）。
+
+命中時 block，訊息附上正確呼叫指令範例與
+`skills/harness-discipline/references/artifact-ownership.md` 規則 4 的提醒；
+不命中或輸入異常一律 fail-open，靜默放行——比照
+`hooks/delegation_criteria_check.py` 的風格：PreToolUse 的 `approve` 等於跳過
+權限系統，這個 hook 沒有資格代替使用者做那個決定，放行不輸出任何 decision
+payload。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _hook_io import emit
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+try:
+    from artifact_path import _KNOWN_KINDS
+except Exception:
+    # fail-open: `scripts/artifact_path.py` is still evolving (kinds get added,
+    # syntax can momentarily break). An empty tuple makes `_KIND_ALTERNATION`
+    # below an empty string, so `_LEGACY_ARTIFACT_RE` never matches anything —
+    # no extra branch needed, this hook just silently stops blocking until the
+    # import is fixed, instead of taking down every Write/Edit in every repo.
+    _KNOWN_KINDS = ()
+
+# 比對時先試最長的 kind，理由同 `scripts/maigo_dir_catalog.py`：避免短 kind
+# （如 "review"）搶先吃掉長 kind 的檔名（如 "review-rubric.md"）。regex 本身
+# 靠 `\.md$` 錨定與整體回溯就不會誤判，這裡沿用同一慣例只是為了可讀性一致。
+_KINDS_BY_LENGTH_DESC = sorted(_KNOWN_KINDS, key=len, reverse=True)
+_KIND_ALTERNATION = "|".join(re.escape(kind) for kind in _KINDS_BY_LENGTH_DESC)
+_LEGACY_ARTIFACT_RE = re.compile(rf"(^|/)\.maigo/({_KIND_ALTERNATION})\.md$")
+
+
+def is_legacy_artifact_path(file_path: str) -> str | None:
+    """命中舊固定檔名回傳該 kind，否則回 `None`。純函式，不做任何 I/O。"""
+    match = _LEGACY_ARTIFACT_RE.search(file_path)
+    if match is None:
+        return None
+    return match.group(2)
+
+
+def _block_reason(kind: str, file_path: str) -> str:
+    return (
+        f"`{file_path}` 是 `.maigo/` 底下舊固定檔名的 `{kind}` 產物，"
+        "只可讀、不可當寫入目標（跨 13 個裝了 maigo 的 repo 實測，這套舊寫法的"
+        "採用率仍是多數——散文擋不住，所以這裡改用程式碼擋）。\n"
+        "改用：\n"
+        f'  python3 scripts/artifact_path.py {kind} --topic "<H1 主題>"\n'
+        "取得帶識別碼的新路徑（`path:` 那行），寫到那裡。\n"
+        "見 skills/harness-discipline/references/artifact-ownership.md 規則 4："
+        "舊固定檔名（`legacy_exists:` 那行指的檔案）只可讀、不可當寫入目標。"
+    )
+
+
+def _pass_through() -> NoReturn:
+    """Silent fail-open: no decision payload, so the permission flow is untouched."""
+    sys.exit(0)
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        try:
+            data = json.loads(raw) if raw.strip() else {}
+        except json.JSONDecodeError:
+            _pass_through()
+
+        if data.get("tool_name") not in ("Write", "Edit"):
+            _pass_through()
+
+        tool_input = data.get("tool_input")
+        if not isinstance(tool_input, dict):
+            _pass_through()
+
+        file_path = tool_input.get("file_path")
+        if not isinstance(file_path, str) or not file_path.strip():
+            _pass_through()
+
+        kind = is_legacy_artifact_path(file_path)
+        if kind:
+            emit("block", _block_reason(kind, file_path))
+        _pass_through()
+    except SystemExit:
+        raise
+    except Exception:
+        # Belt-and-suspenders fail-open, same spirit as `hooks/repo_detect.py`'s
+        # top-level `try/except Exception` — any unforeseen error in this hook
+        # must never take down the caller's Write/Edit. `_pass_through()` is
+        # this hook's own established fail-open action (silent, no payload),
+        # so reuse it here rather than `repo_detect.py`'s explicit
+        # `emit("approve", "")` — the two hooks intentionally differ in
+        # verbosity, not in the fail-open outcome.
+        _pass_through()
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
       - Hooks: reference/hooks.md
       - Skills: reference/skills.md
       - Memory: reference/memory.md
+      - Artifacts: reference/artifacts.md
       - Character colors: reference/character-colors.md
   - Guides:
       - Getting Started: guides/getting-started.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ module = [
   "_token_usage",
   "artifact_path",
   "board_state",
+  "maigo_dir_catalog",
 ]
 ignore_missing_imports = true
 

--- a/scripts/artifact_path.py
+++ b/scripts/artifact_path.py
@@ -3,8 +3,9 @@
 Single source of truth for `.maigo/` markdown artifact paths (naming + ownership).
 
 背景見 `.maigo/plan-maigo-artifact-collision.md`：`.maigo/` 底下固定檔名的
-產物（`plan.md` / `review-rubric.md` / `triage-rubric.md` / `pr-comments.md`）
-被兩個並行 session 覆寫過一次，因為它們共用同一個檔名，語意上卻該有各自一份。
+產物（`plan.md` / `review-rubric.md` / `review.md` / `triage-rubric.md` /
+`pr-comments.md`）被兩個並行 session 覆寫過一次，因為它們共用同一個檔名，
+語意上卻該有各自一份。
 
 這個模組有**雙職責**，都是為了讓「拿到路徑就整份覆寫」在 API 層面做不到：
 
@@ -55,7 +56,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from board_state import github_ref
 
-_KNOWN_KINDS = ("plan", "review-rubric", "triage-rubric", "pr-comments")
+_KNOWN_KINDS = ("plan", "review-rubric", "review", "triage-rubric", "pr-comments")
 
 _SLUG_INVALID_RE = re.compile(r"[^a-z0-9._-]+")
 _SLUG_COLLAPSE_RE = re.compile(r"-{2,}")

--- a/scripts/board_index.py
+++ b/scripts/board_index.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""跨 repo 唯讀 Work Board 索引：一次回答「現在該我動哪些」，不用逐一 cd 進每個 repo。
+
+背景：`.maigo/board.md` 綁 cwd repo 是刻意設計（見
+[`skills/work-board/SKILL.md`](https://github.com/Lee-W/maigo/blob/main/skills/work-board/SKILL.md)），
+但這代表「現在該我動哪些」這句話沒有單一答案——13 個裝了 maigo 的 repo 各自
+一份 board，實測其中 maigo / commitizen / pycon-etl 三份互不相通且過期。這支
+腳本不重寫 board 的行文法，只把每個 repo 的「🎯 下一件」原樣抄一份到單一檔案。
+
+**全程唯讀**：只讀 `<repo>/.maigo/board.md`，不寫回任何被掃描 repo 的 `board.md`
+內容本身，也不重新解析每一行的欄位或合併排序——只逐字複製 `## 🎯 下一件`
+整段。唯一的寫入動作是整份重寫 `~/.config/maigo/board-index.md`（這份索引檔
+本身沒有手寫區、沒有 upsert 語意，每次重新產生，用 `Write` 沒有樂觀鎖疑慮）。
+
+**格式假設已用真實 board.md 驗證過、且證實不成立時要能安全失敗**：本 session
+實際讀了 maigo 自己（新格式）、commitizen（05-30）、pycon-etl（07-25）三份
+真實 board.md——後兩份是**舊版三分區行文法**（`## 🎯 你的球` 而非
+`## 🎯 下一件`，另有 `### 已 review` 這類巢狀子標題、`📥 無法分類`／
+`🗄️ 已放棄` 這類舊 section），header 行雖然仍能被 regex 抽出計數，但找不到
+`## 🎯 下一件` 這個 heading——這正是本腳本要處理的「格式無法解析」情境，不是
+理論假設。header 抽得到、`## 🎯 下一件` 找不到、或兩者皆失敗，一律視為整份
+無法解析（**大聲失敗、不猜、不用只有半邊資料的結果誤導使用者**），且不因為
+某一個 repo 解析失敗就中斷其餘 repo 的處理。
+
+唯讀輸入：`--repo-list <file>`（預設 `~/.config/maigo/repos.txt`，與
+`scripts/migrate_legacy_artifacts.py` 共用同一份清單）。
+
+跑（CLI）：
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/board_index.py" [--repo-list ~/.config/maigo/repos.txt]
+```
+
+核心邏輯 `parse_board_text()` / `build_index()` 是純函式，只吃字串、只吐字串，
+跟「掃 repo 清單、讀檔」的 I/O 完全分離，可被測試用純字串輸入輸出驗證。
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+_DEFAULT_REPO_LIST = Path("~/.config/maigo/repos.txt").expanduser()
+_DEFAULT_OUTPUT = Path("~/.config/maigo/board-index.md").expanduser()
+
+# 例：`> 最後刷新：2026-08-18 14:30 ｜ 🎯 3 ｜ ⏳ 2 ｜ ✅ 1 ｜ 🧠 待學習盤點 1`
+# 只抽日期與三個計數；`🧠` 欄位是 optional，不強制要求存在。
+_HEADER_RE = re.compile(
+    r"^>\s*最後刷新：\s*(?P<date>\S+(?:\s+\S+)?)\s*｜\s*🎯\s*(?P<todo>\d+)"
+    r"\s*｜\s*⏳\s*(?P<waiting>\d+)\s*｜\s*✅\s*(?P<done>\d+)",
+    re.MULTILINE,
+)
+_NEXT_SECTION_HEADING_RE = re.compile(r"^## 🎯 下一件.*$", re.MULTILINE)
+_ANY_SECTION_HEADING_RE = re.compile(r"^## .*$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class BoardHeader:
+    date: str
+    todo: int
+    waiting: int
+    done: int
+
+
+@dataclass(frozen=True)
+class BoardParseResult:
+    ok: bool
+    header: BoardHeader | None
+    next_section_lines: list[str] | None  # `## 🎯 下一件` 原始內容，逐字保留
+
+
+def parse_board_text(text: str) -> BoardParseResult:
+    """解析 `board.md` 的 header 計數 ＋ `## 🎯 下一件` 整段原文。純函式。
+
+    header 抽不到、或找不到 `## 🎯 下一件` 這個 heading（含舊版三分區行文法，
+    heading 是 `## 🎯 你的球`）→ `ok=False`，兩個欄位都是 `None`——整份視為
+    無法解析，不回傳只有一半資料的結果。
+    """
+    header_match = _HEADER_RE.search(text)
+    heading_match = _NEXT_SECTION_HEADING_RE.search(text)
+    if header_match is None or heading_match is None:
+        return BoardParseResult(ok=False, header=None, next_section_lines=None)
+
+    header = BoardHeader(
+        date=header_match.group("date"),
+        todo=int(header_match.group("todo")),
+        waiting=int(header_match.group("waiting")),
+        done=int(header_match.group("done")),
+    )
+
+    body_start = heading_match.end()
+    next_heading = _ANY_SECTION_HEADING_RE.search(text, pos=body_start)
+    body_end = next_heading.start() if next_heading else len(text)
+    body = text[body_start:body_end]
+    lines = body.strip("\n").splitlines()
+
+    return BoardParseResult(ok=True, header=header, next_section_lines=lines)
+
+
+@dataclass(frozen=True)
+class RepoBoardEntry:
+    name: str
+    path: str
+    status: str  # "ok" | "no_board" | "unparseable"
+    result: BoardParseResult | None = None
+
+
+def scan_repo_board(repo_path: str | Path) -> RepoBoardEntry:
+    """讀 `<repo>/.maigo/board.md`，回傳這個 repo 的索引項目。唯讀 I/O。"""
+    repo = Path(repo_path)
+    board_path = repo / ".maigo" / "board.md"
+    if not board_path.is_file():
+        return RepoBoardEntry(name=repo.name, path=str(repo), status="no_board")
+
+    text = board_path.read_text(encoding="utf-8")
+    result = parse_board_text(text)
+    if not result.ok:
+        return RepoBoardEntry(
+            name=repo.name, path=str(repo), status="unparseable", result=result
+        )
+    return RepoBoardEntry(name=repo.name, path=str(repo), status="ok", result=result)
+
+
+def build_index(entries: list[RepoBoardEntry], generated_at: str) -> str:
+    """把每個 repo 的索引項目彙整成整份 `board-index.md` 內容。純函式。"""
+    total = len(entries)
+    with_board = sum(1 for e in entries if e.status == "ok")
+
+    lines = [
+        "# maigo Cross-repo Board Index",
+        f"> 產生於：{generated_at} ｜ {total} 個 repo（{with_board} 有 board）",
+        "",
+    ]
+
+    for entry in entries:
+        lines.append(f"## {entry.name}（{entry.path}）")
+        if entry.status == "no_board":
+            lines.append("")
+            lines.append("(no board)")
+            lines.append("")
+            continue
+        if entry.status == "unparseable":
+            lines.append("")
+            lines.append(f"⚠️ 格式無法解析，開 `{entry.path}/.maigo/board.md` 手動查")
+            lines.append("")
+            continue
+
+        # status == "ok" 時 scan_repo_board() 保證 result 與其兩個欄位都非
+        # None（見該函式與 parse_board_text() 的合約），這裡 assert 只是給
+        # mypy 一個型別窄化的錨點，不是新的執行期防呆。
+        assert entry.result is not None
+        assert entry.result.header is not None
+        assert entry.result.next_section_lines is not None
+        header = entry.result.header
+        lines.append(
+            f"> 🎯 {header.todo} ｜ ⏳ {header.waiting} ｜ ✅ {header.done} "
+            f"｜ 最後刷新：{header.date}"
+        )
+        lines.append("")
+        lines.extend(entry.result.next_section_lines)
+        lines.append("")
+
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def _read_repo_list(path: Path) -> list[str]:
+    if not path.is_file():
+        return []
+    repos = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        repos.append(line)
+    return repos
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-list",
+        default=str(_DEFAULT_REPO_LIST),
+        help="一行一個絕對路徑的純文字檔，預設 ~/.config/maigo/repos.txt",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(_DEFAULT_OUTPUT),
+        help="輸出檔路徑，預設 ~/.config/maigo/board-index.md",
+    )
+    args = parser.parse_args(argv)
+
+    repos = _read_repo_list(Path(args.repo_list).expanduser())
+    entries = [scan_repo_board(repo) for repo in repos]
+
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    content = build_index(entries, generated_at)
+
+    output_path = Path(args.output).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
+
+    print(f"path: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/maigo_dir_catalog.py
+++ b/scripts/maigo_dir_catalog.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Single source of truth for `.maigo/` top-level markdown 型錄分類。
+
+背景：`.maigo/` 頂層散著沒有主人的舊檔（`board-design.md` / `index.md` /
+`plan.md` 這類），沒有任何一份文件或程式碼描述「`.maigo/` 底下有哪些檔、
+各自的正典是誰」。這支腳本是唯讀掃描器，把每個頂層 `*.md` 檔分成四類。
+
+**不重複列一份 kind 清單字面值**——已知種類直接 `from scripts.artifact_path
+import _KNOWN_KINDS`，這是唯一正典來源；平行維護第二份清單正是要避免的漂移。
+
+四類：
+
+(a) 已知種類的識別碼命名：`<kind>-<id>.md`，`kind` 屬於 `_KNOWN_KINDS`
+    （例：`plan-fix-dag-run-stall.md`、`review-42.md`）
+(b) 已知種類的舊固定檔名：`<kind>.md`（例：`plan.md`、`review-rubric.md`）
+(c) 已登記的非 artifact 檔——目前只有 `board.md`。`.maigo/i/` 整個子目錄
+    不在這支腳本管，`commands/board.md` 已經有自己的孤兒偵測邏輯（比對
+    `.maigo/i/*.md` 與 board 索引行），兩者不要疊床架屋。
+(d) 其餘全部 → 未登記檔案。用「不在白名單內」的反向判準，不列一份已知
+    垃圾檔名的黑名單——黑名單會漏掉下一個手動殘留檔。
+
+`_KNOWN_KINDS` 裡有些 kind 名互為前綴（`review` / `review-rubric`），比對時
+一律先試最長的 kind，避免 `review-rubric-42.md` 被 `review` 錯誤搶先吃掉
+（吃成 kind="review", id="rubric-42"）。
+
+純函式：`categorize(names)` 不做任何 I/O。`scan(maigo_dir)` 做唯讀 I/O
+（列出目錄內容），不建立、不覆寫、不刪除任何檔案。
+
+跑（CLI）：
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/maigo_dir_catalog.py" [--dir .maigo]
+```
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from artifact_path import _KNOWN_KINDS
+
+_REGISTERED_NON_ARTIFACT_FILES = ("board.md",)
+
+# 比對時先試最長的 kind，避免短 kind（如 "review"）搶先吃掉長 kind 的檔名
+# （如 "review-rubric-42.md"）。
+_KINDS_BY_LENGTH_DESC = tuple(sorted(_KNOWN_KINDS, key=len, reverse=True))
+
+
+@dataclass
+class Catalog:
+    identifier_named: list[str] = field(default_factory=list)
+    legacy_fixed_name: list[str] = field(default_factory=list)
+    registered_non_artifact: list[str] = field(default_factory=list)
+    unregistered: list[str] = field(default_factory=list)
+
+
+def categorize(names: list[str]) -> Catalog:
+    """把一批頂層 `.maigo/*.md` 檔名分成四類。純函式，不做任何 I/O。"""
+    catalog = Catalog()
+    for name in sorted(names):
+        if not name.endswith(".md"):
+            catalog.unregistered.append(name)
+            continue
+        stem = name[: -len(".md")]
+
+        if name in _REGISTERED_NON_ARTIFACT_FILES:
+            catalog.registered_non_artifact.append(name)
+            continue
+
+        matched_kind = None
+        for kind in _KINDS_BY_LENGTH_DESC:
+            if stem == kind:
+                matched_kind = ("legacy", kind)
+                break
+            if stem.startswith(f"{kind}-") and len(stem) > len(kind) + 1:
+                matched_kind = ("identifier", kind)
+                break
+
+        if matched_kind is None:
+            catalog.unregistered.append(name)
+        elif matched_kind[0] == "legacy":
+            catalog.legacy_fixed_name.append(name)
+        else:
+            catalog.identifier_named.append(name)
+
+    return catalog
+
+
+def scan(maigo_dir: str | Path) -> Catalog:
+    """對給定的 `.maigo/` 目錄做唯讀掃描，只看頂層 `*.md` 檔（不遞迴進 `i/`）。
+
+    目錄不存在時回傳全空的 `Catalog`（不建立目錄，不當錯誤）。
+    """
+    root = Path(maigo_dir)
+    if not root.is_dir():
+        return Catalog()
+    names = [p.name for p in root.iterdir() if p.is_file() and p.suffix == ".md"]
+    return categorize(names)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dir", default=".maigo", help="要掃描的 .maigo/ 目錄（預設 .maigo）"
+    )
+    args = parser.parse_args(argv)
+
+    catalog = scan(args.dir)
+
+    print("identifier_named:")
+    for name in catalog.identifier_named:
+        print(f"  {name}")
+    print("legacy_fixed_name:")
+    for name in catalog.legacy_fixed_name:
+        print(f"  {name}")
+    print("registered_non_artifact:")
+    for name in catalog.registered_non_artifact:
+        print(f"  {name}")
+    print("unregistered:")
+    for name in catalog.unregistered:
+        print(f"  {name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_legacy_artifacts.py
+++ b/scripts/migrate_legacy_artifacts.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""跨 repo 一次搬完 `.maigo/` 底下的舊固定檔名（`plan.md`、`review-rubric.md`……）。
+
+背景：13 個實際安裝 maigo 的 repo 一查，命名規範（`<kind>-<id>.md`）的採用率
+是 0%——這支腳本是把散落各處的舊檔一次遷移到新命名的收尾動作，跟
+`hooks/legacy_artifact_path_check.py`（擋新的寫入）是同一問題的兩端。
+
+**只在 `tmp_path` 假 repo 上跑過 `--apply` 測試——不對任何真實 repo 執行
+`--apply`**，那是跨出本 repo 範圍的不可逆操作，需要使用者逐一確認範圍與
+執行者才動手（見 `.maigo/plan-main.md` 的 Open question 1）。
+
+唯讀輸入：接受一或多個 repo 根目錄（positional args），或 `--repo-list <file>`
+讀一份純文字檔（每行一個絕對路徑，空行與 `#` 開頭的行忽略），預設
+`--repo-list ~/.config/maigo/repos.txt`（與 `scripts/board_index.py` 共用
+同一份清單）。
+
+對每個 repo：`from maigo_dir_catalog import scan` 拿 `legacy_fixed_name` 清單
+（不重寫分類邏輯）。對每個命中檔案：讀該檔 H1 → `slugify(H1 文字)` 算新識別
+碼；H1 缺失或 slugify 回 `None` → 退回 `slugify(檔名去副檔名) or "unnamed"`。
+
+**去疊字**：這些舊檔的 H1 常常以 kind 名開頭（`# Plan: ...`、
+`# Review rubric — ...`），slugify 後再接上 `<kind>-` 前綴組檔名就會疊成
+`plan-plan-...`。算出識別碼後若它等於該檔自己的 kind、或以 `<kind>-`
+開頭，去掉那段前綴；去掉後變空字串就退回下一級 fallback（H1 slug 去疊字
+空了退到檔名 stem，stem 去疊字也空了退到 `"unnamed"`）。只比對「這份檔案
+自己的 kind」，不比對 `_KNOWN_KINDS` 全部種類——比對全部種類會把恰好以
+另一個 kind 名開頭的不相干內容也錯誤地砍掉。
+
+**截斷邊界**：`slugify()` 的 40 字元硬截斷可能切在字中間；只有本模組（不
+動 `scripts/artifact_path.py` 共用的 `slugify()`——那邊的逐字截斷行為被
+`test_artifact_path.py::TestSlugify::test_truncates_to_40_chars` 鎖定，且被
+branch 名等其他呼叫端共用）在偵測到識別碼命中 40 字元上限時，退到最後一個
+完整的 `-` 分段邊界，避免產生像 `...review-c2` 這種攔腰截斷的尾巴。
+
+**刻意不用 branch 名**：遷移當下的 git branch 未必是當初寫檔時的 branch，
+`resolve_identifier()` 的四級鏈第 2 級（當前 branch）在「事後遷移一份不知道
+何時寫的舊檔」這個情境下不成立——這是刻意的取捨，不是漏做了。
+
+目標路徑已存在（不論是撞到本次一起遷移的另一份舊檔、還是撞到該 repo已有的
+新命名檔案，都是同一種「目標路徑已存在」判斷，衝突偵測涵蓋 `.maigo/` 底下
+**所有既存檔案**）→ 自動加 `-2`/`-3` 尾碼直到不衝突，在報告中標記這筆是自動
+消歧的，不靜默覆蓋任何既有檔案。
+
+預設 dry-run：只印 `<repo> :: <old> -> <new>` 表格，不動任何檔案。`--apply`
+才真的 `Path.rename()`（純檔案系統操作，不是 `git mv`——`.maigo/` 不受版控）。
+
+Idempotent：對已無 `legacy_fixed_name` 的 repo，印 `(nothing to migrate)`，
+重跑不出錯、不重複改名。
+
+跑（CLI）：
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/migrate_legacy_artifacts.py" \
+    [--repo-list ~/.config/maigo/repos.txt] [--apply] [<repo>...]
+```
+
+核心邏輯 `plan_migration()` 是純函式（讀 H1 屬唯讀 I/O，不寫任何檔案）；
+`apply_migration()` 才是唯一會寫入檔案系統的入口。
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from artifact_path import _SLUG_MAX_LEN, artifact_path, read_topic, slugify
+from maigo_dir_catalog import Catalog, scan
+
+_DEFAULT_REPO_LIST = Path("~/.config/maigo/repos.txt").expanduser()
+
+
+@dataclass(frozen=True)
+class MigrationAction:
+    repo: str
+    old_path: str  # repo-relative，例：".maigo/plan.md"
+    new_path: str  # repo-relative，例：".maigo/plan-fix-dag-run.md"
+    disambiguated: bool  # True＝目標撞名，自動加了 -2/-3 尾碼
+
+
+def _existing_top_level_names(maigo_dir: Path) -> set[str]:
+    """`.maigo/` 頂層目前有的所有檔名（唯讀，不遞迴進 `i/`）。"""
+    if not maigo_dir.is_dir():
+        return set()
+    return {p.name for p in maigo_dir.iterdir() if p.is_file()}
+
+
+def _strip_kind_stutter(kind: str, identifier: str) -> str:
+    """去掉識別碼開頭與 kind 重複的部分，避免組出 `<kind>-<kind>-...` 的疊字檔名。
+
+    只比對這份檔案自己的 `kind`（呼叫端已知，不是搜尋 `_KNOWN_KINDS` 全部
+    種類）——比對全部種類會有誤殺風險：若某份 `pr-comments.md` 的 H1 恰好
+    誤用了別的模板、寫成「Plan: ...」開頭，比對全部種類會把這段不相干的
+    「plan-」前綴也砍掉，那不是這支函式要修的疊字問題。
+    """
+    if identifier == kind:
+        return ""
+    prefix = f"{kind}-"
+    if identifier.startswith(prefix):
+        return identifier[len(prefix) :]
+    return identifier
+
+
+def _trim_to_word_boundary(text: str) -> str:
+    """`slugify()` 的 40 字元硬截斷可能切在字中間；退到最後一個完整的 `-`
+    分段邊界，捨去被攔腰截斷的尾段。沒有 `-` 可退（單一長字）就原樣回傳。
+    """
+    if "-" not in text:
+        return text
+    trimmed, _, _tail = text.rpartition("-")
+    return trimmed or text
+
+
+def _infer_identifier(maigo_dir: Path, kind: str, legacy_name: str) -> str:
+    """讀 legacy 檔的 H1 slugify 當識別碼；缺 H1 或 slugify 失敗則退回檔名本身。
+
+    去疊字與截斷邊界處理見模組 docstring；`kind` 由呼叫端算好傳入
+    （`legacy_name` 去掉 `.md`），不在這裡重算。
+    """
+    h1 = read_topic(maigo_dir / legacy_name)
+    if h1:
+        slug = slugify(h1)
+        if slug:
+            if len(slug) >= _SLUG_MAX_LEN:
+                slug = _trim_to_word_boundary(slug)
+            deduped = _strip_kind_stutter(kind, slug)
+            if deduped:
+                return deduped
+    stem = legacy_name[: -len(".md")] if legacy_name.endswith(".md") else legacy_name
+    stem_slug = slugify(stem) or "unnamed"
+    return _strip_kind_stutter(kind, stem_slug) or "unnamed"
+
+
+def plan_migration(repo_root: str | Path, catalog: Catalog) -> list[MigrationAction]:
+    """算出這個 repo 該搬哪些檔、搬去哪——純函式，只做唯讀 I/O（讀 H1、列既存檔名）。
+
+    `catalog` 由呼叫端先 `scan()` 好傳進來，這支函式不自己重掃。
+    """
+    maigo_dir = Path(repo_root) / ".maigo"
+    reserved = _existing_top_level_names(maigo_dir)
+    actions: list[MigrationAction] = []
+
+    for legacy_name in catalog.legacy_fixed_name:
+        kind = legacy_name[: -len(".md")]
+        old_rel = f".maigo/{legacy_name}"
+
+        base_identifier = _infer_identifier(maigo_dir, kind, legacy_name)
+        identifier = base_identifier
+        candidate_name = Path(artifact_path(kind, identifier)).name
+
+        disambiguated = False
+        suffix = 2
+        while candidate_name in reserved:
+            identifier = f"{base_identifier}-{suffix}"
+            candidate_name = Path(artifact_path(kind, identifier)).name
+            disambiguated = True
+            suffix += 1
+
+        reserved.add(candidate_name)
+        actions.append(
+            MigrationAction(
+                repo=str(repo_root),
+                old_path=old_rel,
+                new_path=f".maigo/{candidate_name}",
+                disambiguated=disambiguated,
+            )
+        )
+
+    return actions
+
+
+def apply_migration(repo_root: str | Path, actions: list[MigrationAction]) -> None:
+    """唯一會真的動檔案的入口：`Path.rename()`（純檔案系統操作，`.maigo/` 不受版控，
+    不用 `git mv`）。"""
+    for action in actions:
+        old = Path(repo_root) / action.old_path
+        new = Path(repo_root) / action.new_path
+        old.rename(new)
+
+
+def _read_repo_list(path: Path) -> list[str] | None:
+    """讀清單檔；檔案不存在或讀不到（權限拒絕等）一律回 `None` 讓呼叫端印
+    明確錯誤並回非 0 exit code——不能讓「路徑打錯」跟「清單裡真的沒東西」
+    看起來一樣（都是印 `(nothing to migrate)`）。
+    """
+    try:
+        if not path.is_file():
+            return None
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    repos = []
+    for raw in raw_text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        repos.append(line)
+    return repos
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "repos", nargs="*", help="repo 根目錄（未給時改讀 --repo-list）"
+    )
+    parser.add_argument(
+        "--repo-list",
+        default=str(_DEFAULT_REPO_LIST),
+        help="一行一個絕對路徑的純文字檔，預設 ~/.config/maigo/repos.txt",
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="真的執行 rename；預設只 dry-run 印清單"
+    )
+    args = parser.parse_args(argv)
+
+    if args.repos:
+        repos = args.repos
+    else:
+        repo_list_path = Path(args.repo_list).expanduser()
+        repos = _read_repo_list(repo_list_path)
+        if repos is None:
+            print(
+                f"error: --repo-list file not found or unreadable: {repo_list_path}",
+                file=sys.stderr,
+            )
+            return 1
+        if not repos:
+            print(
+                "error: --repo-list file has no repo paths "
+                f"(all blank/comment lines?): {repo_list_path}",
+                file=sys.stderr,
+            )
+            return 1
+
+    for repo in repos:
+        repo_path = Path(repo)
+        if not repo_path.is_dir():
+            print(f"{repo} :: skipped (repo path does not exist)")
+            continue
+
+        catalog = scan(repo_path / ".maigo")
+        actions = plan_migration(repo, catalog)
+
+        if not actions:
+            print(f"{repo} :: (nothing to migrate)")
+            continue
+
+        for action in actions:
+            marker = " [auto-disambiguated]" if action.disambiguated else ""
+            print(f"{repo} :: {action.old_path} -> {action.new_path}{marker}")
+
+        if args.apply:
+            apply_migration(repo, actions)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/worktree_path.py
+++ b/scripts/worktree_path.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Single source of truth for computing a sibling worktree's path + branch name.
+
+背景：`skills/git-workflow/references/worktree-hygiene.md`（第 10–16 行）已經定義
+好佈局慣例——worktree 是**主 checkout 的 sibling**，跟主 clone 放在同一個父目錄下，
+命名 `<repo>-<topic>`，branch 名就是 `<topic>` 本身（不加前綴、不加 issue number）。
+這支腳本只是把那條散文規則變成可重複執行的計算，**不發明新的路徑規則**。
+
+純函式運算（跟 `artifact_path.py` 的命名層同一種「純計算」定位）：不跑任何 git
+子行程、不建立任何檔案或 worktree——真的開 worktree 是呼叫端的事
+（`git worktree add`），這支腳本只算路徑跟 branch 名。
+
+複用既有的 `slugify()`（`scripts/artifact_path.py`），不重寫一份正則；
+`slugify()` 回傳 `None`（空字串／純 CJK）時退回 `"unnamed"`，跟
+`resolve_identifier()` 第四級 fallback 邏輯一致，不另創規則。
+
+跑（CLI）：
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/worktree_path.py" \
+    --repo <name> --topic "<自由文字>" [--cwd DIR]
+```
+
+stdout 兩行：`path: <cwd 的父目錄>/<repo>-<slug>`、`branch: <slug>`。
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from artifact_path import slugify
+
+
+@dataclass(frozen=True)
+class WorktreeLocation:
+    path: str
+    branch: str
+
+
+def compute_worktree_location(
+    repo: str, topic: str, cwd: str | Path = "."
+) -> WorktreeLocation:
+    """算出 sibling worktree 的路徑與 branch 名。純函式，不做任何 I/O。"""
+    slug = slugify(topic) or "unnamed"
+    parent = Path(cwd).resolve().parent
+    path = parent / f"{repo}-{slug}"
+    return WorktreeLocation(path=str(path), branch=slug)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="主 checkout 的 repo 名")
+    parser.add_argument(
+        "--topic", required=True, help="自由文字，會被 slugify 成 branch 名"
+    )
+    parser.add_argument(
+        "--cwd", default=".", help="主 checkout 目錄；worktree 開在它的父目錄下"
+    )
+    args = parser.parse_args(argv)
+
+    location = compute_worktree_location(args.repo, args.topic, cwd=args.cwd)
+
+    print(f"path: {location.path}")
+    print(f"branch: {location.branch}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -238,6 +238,14 @@ parallel or an unverified delegate report. Details and recipes in
 Read `references/worktree-hygiene.md` when opening/cleaning up worktrees or
 when git history looks surprising after a delegated task.
 
+### Worktree automation (`--worktree` flag)
+
+How `/maigo:go` / `/maigo:take-issue`'s opt-in `--worktree` flag actually opens
+a sibling worktree, and where `.maigo/` artifacts written during that task
+belong (per-task artifacts vs. the Work Board, which only ever lives in the
+main checkout). Details in
+[`references/worktree-automation.md`](https://github.com/Lee-W/maigo/blob/main/skills/git-workflow/references/worktree-automation.md).
+
 ## Shared worktree state volatility (references)
 
 A shared worktree's branch, commits, or push/PR state can change from

--- a/skills/git-workflow/references/worktree-automation.md
+++ b/skills/git-workflow/references/worktree-automation.md
@@ -1,0 +1,78 @@
+# Git Workflow — Worktree Automation (`--worktree` flag)
+
+Loaded on demand by `skills/git-workflow/SKILL.md` — **how the `--worktree` opt-in
+flag on `/maigo:go` and `/maigo:take-issue` actually opens a sibling worktree, and
+where `.maigo/` artifacts written during that task belong.** Read this before
+briefing an agent that will operate inside a freshly-opened worktree, or when
+deciding whether a `.maigo/` write during a worktree task should land in the
+worktree or the main checkout.
+
+---
+
+## 1. How `--worktree` wires up
+
+`/maigo:go` and `/maigo:take-issue` each accept an optional `--worktree` flag
+(opt-in, off by default). When present, **before** 🐱 樂奈 starts, the
+orchestrator itself (not a delegated agent) runs:
+
+```bash
+git fetch <remote>
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/worktree_path.py" --repo <name> --topic "<任務描述或 issue 標題>"
+git worktree add -b <branch> <path> <remote>/<default-branch>
+```
+
+- **Fetch first, always.** Cutting a worktree from a stale local tracking ref
+  risks branching off a commit the remote has already moved past. `<remote>`
+  resolution: try `upstream` first, fall back to `origin` — mirrors the
+  sibling-layout convention in
+  [`references/worktree-hygiene.md`](https://github.com/Lee-W/maigo/blob/main/skills/git-workflow/references/worktree-hygiene.md).
+- `scripts/worktree_path.py` is a pure function — it only computes the sibling
+  path and branch name (reusing `slugify()` from `scripts/artifact_path.py`,
+  same rules as artifact identifiers). It does **not** run any git subprocess
+  or create anything; the actual `git worktree add` is the orchestrator's own
+  step, right after.
+- Once the worktree exists, **every delegate prompt for the rest of that task**
+  (🐱 樂奈 / 🩵 燈 / 🎀 愛音 / 🟡 爽世 / 🟣 立希) must carry that worktree's
+  absolute path as its explicit cwd — see
+  [`skills/teammate-flow/SKILL.md`](https://github.com/Lee-W/maigo/blob/main/skills/teammate-flow/SKILL.md)'s
+  cwd-repetition rule for why "the previous agent already said it" isn't
+  enough (five independent agent contexts, no implicit inheritance).
+- At hand-off (🟣 立希 all-green, commit drafted), the orchestrator prints the
+  worktree's path and branch, and says explicitly: it's left in place, and
+  `/maigo:repo-audit`'s new "已合併可清的 sibling worktree" section (see
+  `commands/repo-audit.md`) will surface it as a cleanup candidate once its PR
+  merges. **The worktree is never removed automatically here.**
+
+## 2. `.maigo/` ownership inside a worktree task
+
+Two different things live under `.maigo/`, and they have **opposite**
+locality rules:
+
+| What | Where it lives | Why |
+|------|----------------|-----|
+| Single-task temporary artifacts (`plan-<id>.md`, `review-rubric-<id>.md`, `review-<id>.md`, `triage-rubric-<id>.md`, `pr-comments-<id>.md`) | The **worktree's own** `.maigo/` | `artifact_path.py`'s `resolve_identifier()` derives the identifier from cwd's current git branch. cwd inside the worktree naturally resolves to the worktree's own branch slug — no code change needed, it just falls out of the existing four-tier identifier chain. |
+| Work Board (`.maigo/board.md` and `.maigo/i/*.md`) | **Always the main checkout**, never a worktree | The board is a cross-session, cross-task single source of truth — it doesn't make sense duplicated per worktree. |
+
+When a command running inside a worktree needs to read or write the board, it
+must first resolve the shared main checkout root — never assume cwd is it:
+
+```bash
+git rev-parse --path-format=absolute --git-common-dir
+```
+
+The parent directory of that path is the main checkout root; all board reads
+and writes go there, not to cwd.
+
+## 3. This rule survives the cross-repo rewrite unchanged
+
+The "board only lives in the main checkout" rule above predates this plan's
+cross-repo scope, and stays exactly as written — the cross-repo board index
+(`scripts/board_index.py`, see `docs/reference/artifacts.md`) is a *different*
+layer (it reads each repo's own main-checkout `board.md` across many repos);
+worktree-vs-main-checkout locality within a single repo is orthogonal to it.
+
+**One thing to watch when building `~/.config/maigo/repos.txt`**: every entry
+must be a repo's **main checkout** path, never a sibling worktree path. A
+worktree has no board of its own — scanning one either hits the same board
+file shared via the common `.git` dir, or hits nothing (the board file only
+physically exists under the main checkout directory).

--- a/skills/harness-discipline/SKILL.md
+++ b/skills/harness-discipline/SKILL.md
@@ -46,8 +46,8 @@ description: This skill should be used when the maigo orchestrator, running in t
 
 ## `.maigo/` 產物歸屬
 
-`.maigo/` 底下 agent 寫的 markdown 產物（plan / review-rubric / triage-rubric /
-pr-comments 這類）一律呼叫 `scripts/artifact_path.py` 取路徑，不要自己組檔名、
+`.maigo/` 底下 agent 寫的 markdown 產物（plan / review-rubric / review /
+triage-rubric / pr-comments 這類）一律呼叫 `scripts/artifact_path.py` 取路徑，不要自己組檔名、
 也不要自己記得比對 H1——判斷邏輯在有測試把關的程式碼裡，散文只提醒你呼叫它。
 完整規則見
 [`references/artifact-ownership.md`](https://github.com/Lee-W/maigo/blob/main/skills/harness-discipline/references/artifact-ownership.md)。

--- a/skills/harness-discipline/references/artifact-ownership.md
+++ b/skills/harness-discipline/references/artifact-ownership.md
@@ -2,17 +2,20 @@
 
 Loaded on demand by [`skills/harness-discipline/SKILL.md`](https://github.com/Lee-W/maigo/blob/main/skills/harness-discipline/SKILL.md) —
 `.maigo/` 底下 agent 寫的 markdown 產物（`plan.md` / `review-rubric.md` /
-`triage-rubric.md` / `pr-comments.md` 這類）曾經被兩個並行 session 靜默覆寫過，
-因為它們共用同一個固定檔名，語意上卻該有各自一份。Read this file when 你要在
-`.maigo/` 寫入這類 markdown 產物、或需要幫它取路徑之前。
+`review.md` / `triage-rubric.md` / `pr-comments.md` 這類）曾經被兩個並行
+session 靜默覆寫過，因為它們共用同一個固定檔名，語意上卻該有各自一份。
+Read this file when 你要在 `.maigo/` 寫入這類 markdown 產物、或需要幫它取
+路徑之前。`.maigo/` 全貌型錄（含非 markdown 機器狀態檔、Work Board、舊固定
+檔名與未登記檔案）見
+[`docs/reference/artifacts.md`](https://github.com/Lee-W/maigo/blob/main/docs/reference/artifacts.md)。
 
 ---
 
 ## 規則（四條，全部程式碼強制，不是靠你記得檢查）
 
 1. **每份這類 markdown 必須以能識別主題的 H1 開頭**（例：`# Plan: <task>`、
-   `# Review rubric: <PR title>`、`# Triage rubric: <issue title> (#<N>)`、
-   `# PR comments: <PR title> (#<number>)`）。
+   `# Review rubric: <PR title>`、`# Review: <PR title / branch / range>`、
+   `# Triage rubric: <issue title> (#<N>)`、`# PR comments: <PR title> (#<number>)`）。
 
    這些範例**必須與各自模板實際寫出的 H1 逐字相同** —— `--topic` 與 H1 對不上，
    `same_topic` 就不成立，續跑會被誤判成 `conflict`。pr-comments 的權威模板在
@@ -37,7 +40,10 @@ Loaded on demand by [`skills/harness-discipline/SKILL.md`](https://github.com/Le
 
 4. **舊固定檔名（stdout 的 `legacy_exists:` 那行指的檔案）只可讀、不可當寫入
    目標**——有續跑語意的產物（如 `plan.md`）在新路徑讀不到內容時可以退回讀舊
-   檔繼續，但下一次寫入一律寫到 script 回的新路徑，不回寫舊檔。
+   檔繼續，但下一次寫入一律寫到 script 回的新路徑，不回寫舊檔。這條現在不是只
+   靠你記得——`Write` / `Edit` 寫入 `.maigo/` 底下的舊固定檔名會被
+   [`hooks/legacy_artifact_path_check.py`](https://github.com/Lee-W/maigo/blob/main/hooks/legacy_artifact_path_check.py)
+   （PreToolUse）直接擋下，訊息會附上正確的 `artifact_path.py` 呼叫指令。
 
 `pr-comments` 另外還有
 [`commands/address-comments.md`](https://github.com/Lee-W/maigo/blob/main/commands/address-comments.md)

--- a/skills/strict-review/references/review-templates.md
+++ b/skills/strict-review/references/review-templates.md
@@ -30,6 +30,13 @@ file when writing the rubric or assembling the final report.
 
 ## 輸出
 
+這個骨架不只是聊天視窗的形狀，現在也是逐字寫進 `.maigo/review-<id>.md`
+（`kind="review"`，見
+[`scripts/artifact_path.py`](https://github.com/Lee-W/maigo/blob/main/scripts/artifact_path.py)，
+呼叫方式見
+[`commands/review.md`](https://github.com/Lee-W/maigo/blob/main/commands/review.md)「## 輸出」）
+的檔案內容——兩者是同一份骨架，不要各自維護一份。
+
 ### 單一 PR / branch / range（預設）
 
 ```markdown

--- a/skills/teammate-flow/SKILL.md
+++ b/skills/teammate-flow/SKILL.md
@@ -69,6 +69,12 @@ Orchestrator 對使用者說話時戴上旁白的臉——開場、收場、卡�
 - 不要跳關。即使任務看起來很小，每一步都要走
 - 完成後給使用者一份最終 summary：改了哪些檔案、test 結果、有沒有未解問題。Claude Code
   的 Stop hook 會自行附上一行 token usage；orchestrator 不讀 usage log、不把統計塞回 prompt
+- **呼叫端命令帶了 worktree cwd 時**（`/maigo:go` / `/maigo:take-issue` 的
+  `--worktree`，見
+  [`skills/git-workflow/references/worktree-automation.md`](https://github.com/Lee-W/maigo/blob/main/skills/git-workflow/references/worktree-automation.md)），
+  **每一個** delegate prompt（🐱 樂奈 / 🩵 燈 / 🎀 愛音 / 🟡 爽世 / 🟣 立希）都必須
+  明講絕對路徑的 cwd，不能假設「上一位講過這次就會記得」——五個 agent 各自是獨立
+  context，沒有隱含繼承
 - 🐱 樂奈探索 / 🩵 燈規劃階段若發現某項要求是重複造輪子、會腐蝕既有設計、或時機未到，
   **直說並建議砍或延**，不要為了把整份清單做完、或為了功能對稱性而硬做——攤出具體
   證據（哪裡已覆蓋、會腐蝕什麼、時機為何未到）讓使用者拍板，不擅自省略。「重複造

--- a/skills/work-board/SKILL.md
+++ b/skills/work-board/SKILL.md
@@ -15,6 +15,16 @@ description: This skill should be used when reading, writing, or migrating `.mai
 [`/maigo:address-comments`](https://github.com/Lee-W/maigo/blob/main/commands/address-comments.md)、
 [`/maigo:describe-pr`](https://github.com/Lee-W/maigo/blob/main/commands/describe-pr.md)（各自的收尾回寫段）
 
+`.maigo/` 全貌型錄（board 在其中的定位、其餘產物種類）見
+[`docs/reference/artifacts.md`](https://github.com/Lee-W/maigo/blob/main/docs/reference/artifacts.md)。
+
+**`~/.config/maigo/board-index.md` 是什麼**：跨 repo 唯讀索引，由
+`scripts/board_index.py`（`/maigo:board --cross-repo` 觸發）產生——回答「這台
+機器裝了 maigo 的所有 repo，現在該我動哪些」這句話，**不是另一份 `board.md`
+正典**。每次重新產生、沒有手寫區、沒有 upsert 語意；只逐字複製各 repo
+`board.md` 的 `## 🎯 下一件` 整段，不重新解析或合併排序。跟本節下面講的
+`board.md` 單一 repo 內的行文法、upsert 合約是完全不同的東西。
+
 ## Why this skill exists
 
 `/maigo:review` 的 `.maigo/review-board.md` 只涵蓋「reviewer 視角」。實際工作面是三種混在一起的球：
@@ -414,6 +424,11 @@ maigo 命令自己處理的項目**不勾 checkbox**——checkbox 專屬「使�
 `.maigo/plan-<id>.md`——或遷移前留下的舊 `.maigo/plan.md`——是否存在、`git log`/`git status`
 做到哪一步）——兩者都能讓 orchestrator 從既有進度接著跑，不必
 等原 session 復活，也不必整個重新走一次 Raana 探索 + Tomori 規劃。
+
+**不確定該任務在哪個 repo時**：這台機器裝了 maigo 的 repo 不只一個，先查
+`~/.config/maigo/board-index.md`（沒有就先跑一次 `/maigo:board --cross-repo`
+產生）縮小範圍，再進到命中的那個 repo 查 `board.md` / `plan-<id>.md`，比逐一
+`cd` 進每個 repo 問一輪快。
 
 ## What this skill does NOT cover
 

--- a/tests/test_artifact_path.py
+++ b/tests/test_artifact_path.py
@@ -58,6 +58,12 @@ class TestNaming:
     def test_legacy_path_format(self):
         assert ap.legacy_path("plan") == ".maigo/plan.md"
 
+    def test_review_artifact_path_format(self):
+        assert ap.artifact_path("review", "x") == ".maigo/review-x.md"
+
+    def test_review_legacy_path_format(self):
+        assert ap.legacy_path("review") == ".maigo/review.md"
+
     @pytest.mark.parametrize(
         "kind",
         [
@@ -215,6 +221,20 @@ class TestResolveForWrite:
         )
         assert result.status == "new"
         assert result.path == ".maigo/plan-42.md"
+        assert result.existing_topic is None
+        assert result.suggested_path is None
+        assert result.legacy_path is None
+
+    def test_new_for_review_kind_when_target_path_absent(self, tmp_path: Path):
+        result = ap.resolve_for_write(
+            "review",
+            "Review: fix dag run stall",
+            url=_URL,
+            home_repo=_HOME_REPO,
+            cwd=tmp_path,
+        )
+        assert result.status == "new"
+        assert result.path == ".maigo/review-42.md"
         assert result.existing_topic is None
         assert result.suggested_path is None
         assert result.legacy_path is None

--- a/tests/test_board_index.py
+++ b/tests/test_board_index.py
@@ -1,0 +1,152 @@
+"""Tests for scripts.board_index — cross-repo, read-only Work Board index.
+
+全程只對 `tmp_path` 底下的假 repo 操作，不觸碰任何真實的其他 12 個 repo。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import board_index as bi
+
+_NEW_STYLE_BOARD = """\
+# Work Board — Lee-W/maigo
+> 最後刷新：2026-08-18 14:30 ｜ 🎯 3 ｜ ⏳ 2 ｜ ✅ 1 ｜ 🧠 待學習盤點 1
+
+## 🎯 下一件（3）
+
+1. [ ] 🔀 CHANGES_REQUESTED i/9201.md — Redesign Work Board reading view
+2. [x] 👀 ↩︎ 回你的球 i/9301.md — Avoid duplicate GitHub requests
+3. [ ] 🐛 待 triage 💤 i/9101.md — CLI 在空設定檔時會 crash
+
+## ⏳ 等別人（2）
+
+- [ ] 🔀 等 review i/9202.md — Document plugin installation flow
+
+## ✅ 最近結案（1）
+
+- [x] 👀 APPROVE（merged 07-12） 🧠 i/9303.md — Add structured review verdicts
+"""
+
+# 真實抽樣（2026-09-08，commitizen 的 .maigo/board.md）——舊版三分區行文法，
+# heading 是「## 🎯 你的球」而非「## 🎯 下一件」，header 計數仍抽得到。
+_OLD_STYLE_BOARD = """\
+# Work Board — commitizen-tools/commitizen
+> 最後刷新：2026-05-30 ｜ 🎯 28 ｜ ⏳ 0 ｜ ✅ 3 ｜ 🧠 待學習盤點 0 ｜ **全 28 顆已 review 完成**
+
+## 🎯 你的球（28）
+
+### 已 review — verdict 待貼上 GitHub（28）
+
+**🟢 APPROVE / APPROVE_WITH_NITS（6）**
+- [ ] 👀 #1967 (bearomorphism) **APPROVE** Δ +12/-0 — some title
+"""
+
+_HEADER_BROKEN_BOARD = """\
+# Work Board — broken/repo
+> this line has no counts at all
+
+## 🎯 下一件（0）
+"""
+
+
+class TestParseBoardText:
+    def test_new_style_board_parses_ok(self):
+        result = bi.parse_board_text(_NEW_STYLE_BOARD)
+
+        assert result.ok is True
+        assert result.header.date == "2026-08-18 14:30"
+        assert result.header.todo == 3
+        assert result.header.waiting == 2
+        assert result.header.done == 1
+        assert any("i/9201.md" in line for line in result.next_section_lines)
+        assert any("i/9101.md" in line for line in result.next_section_lines)
+        # 只到下一個 section 為止，不吃進 ⏳ 等別人 的內容
+        assert not any("i/9202.md" in line for line in result.next_section_lines)
+
+    def test_old_style_three_section_board_is_unparseable(self):
+        result = bi.parse_board_text(_OLD_STYLE_BOARD)
+
+        assert result.ok is False
+        assert result.header is None
+        assert result.next_section_lines is None
+
+    def test_header_regex_failure_is_unparseable(self):
+        result = bi.parse_board_text(_HEADER_BROKEN_BOARD)
+
+        assert result.ok is False
+
+    def test_missing_next_section_heading_is_unparseable(self):
+        text = "# Work Board — x\n> 最後刷新：2026-01-01 ｜ 🎯 0 ｜ ⏳ 0 ｜ ✅ 0\n\n## 其他\n"
+        result = bi.parse_board_text(text)
+
+        assert result.ok is False
+
+
+class TestScanRepoBoard:
+    def test_repo_without_maigo_dir_reports_no_board(self, tmp_path: Path):
+        repo = tmp_path / "no-maigo-repo"
+        repo.mkdir()
+
+        entry = bi.scan_repo_board(repo)
+
+        assert entry.status == "no_board"
+        assert entry.name == "no-maigo-repo"
+
+    def test_repo_with_new_style_board_reports_ok(self, tmp_path: Path):
+        repo = tmp_path / "maigo"
+        (repo / ".maigo").mkdir(parents=True)
+        (repo / ".maigo" / "board.md").write_text(_NEW_STYLE_BOARD, encoding="utf-8")
+
+        entry = bi.scan_repo_board(repo)
+
+        assert entry.status == "ok"
+        assert entry.result.header.todo == 3
+
+    def test_repo_with_old_style_board_reports_unparseable(self, tmp_path: Path):
+        repo = tmp_path / "commitizen"
+        (repo / ".maigo").mkdir(parents=True)
+        (repo / ".maigo" / "board.md").write_text(_OLD_STYLE_BOARD, encoding="utf-8")
+
+        entry = bi.scan_repo_board(repo)
+
+        assert entry.status == "unparseable"
+
+
+class TestBuildIndex:
+    def test_mixed_statuses_all_appear_and_dont_block_each_other(self, tmp_path: Path):
+        ok_repo = tmp_path / "maigo"
+        (ok_repo / ".maigo").mkdir(parents=True)
+        (ok_repo / ".maigo" / "board.md").write_text(_NEW_STYLE_BOARD, encoding="utf-8")
+
+        broken_repo = tmp_path / "commitizen"
+        (broken_repo / ".maigo").mkdir(parents=True)
+        (broken_repo / ".maigo" / "board.md").write_text(
+            _OLD_STYLE_BOARD, encoding="utf-8"
+        )
+
+        empty_repo = tmp_path / "pelican-osm"
+        empty_repo.mkdir()
+
+        entries = [
+            bi.scan_repo_board(ok_repo),
+            bi.scan_repo_board(broken_repo),
+            bi.scan_repo_board(empty_repo),
+        ]
+
+        index = bi.build_index(entries, generated_at="2026-09-08 00:00 UTC")
+
+        assert "# maigo Cross-repo Board Index" in index
+        assert "3 個 repo（1 有 board）" in index
+        assert "## maigo（" in index
+        assert "i/9201.md" in index
+        assert "## commitizen（" in index
+        assert "⚠️ 格式無法解析" in index
+        assert "board.md` 手動查" in index
+        assert "## pelican-osm（" in index
+        assert "(no board)" in index
+
+    def test_empty_entries_produces_zero_counts(self):
+        index = bi.build_index([], generated_at="2026-09-08 00:00 UTC")
+
+        assert "0 個 repo（0 有 board）" in index

--- a/tests/test_legacy_artifact_path_check.py
+++ b/tests/test_legacy_artifact_path_check.py
@@ -1,0 +1,224 @@
+"""Tests for hooks.legacy_artifact_path_check — blocks writes to legacy `.maigo/`
+fixed-name artifacts (`plan.md`, `review-rubric.md`, ...)."""
+
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import sys
+
+import pytest
+
+import hooks.legacy_artifact_path_check as lac
+
+
+def run_silent_hook(
+    payload: dict,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> str:
+    """Run the hook's main() and return raw stdout (empty string = pass-through)."""
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
+    with pytest.raises(SystemExit) as exc:
+        lac.main()
+    assert exc.value.code == 0
+    return capsys.readouterr().out
+
+
+def _write_payload(file_path: str, tool_name: str = "Write") -> dict:
+    return {"tool_name": tool_name, "tool_input": {"file_path": file_path}}
+
+
+class TestIsLegacyArtifactPath:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".maigo/plan.md",
+            ".maigo/review-rubric.md",
+            ".maigo/pr-comments.md",
+            ".maigo/triage-rubric.md",
+            ".maigo/review.md",
+            "/Users/x/repo/.maigo/plan.md",
+        ],
+    )
+    def test_legacy_fixed_names_are_flagged(self, path: str):
+        assert lac.is_legacy_artifact_path(path) is not None
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".maigo/plan-main.md",
+            ".maigo/board.md",
+            ".maigo/local-model-dispatch-plan.md",
+            ".maigo/i/9201.md",
+            "plan.md",
+            "notes/not.maigo/plan.md",
+        ],
+    )
+    def test_non_legacy_paths_are_not_flagged(self, path: str):
+        assert lac.is_legacy_artifact_path(path) is None
+
+    def test_returns_the_matched_kind(self):
+        assert lac.is_legacy_artifact_path(".maigo/review-rubric.md") == "review-rubric"
+
+
+class TestLegacyArtifactPathHook:
+    def test_write_to_plan_md_blocks_with_command_example(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ):
+        result = json.loads(
+            run_silent_hook(
+                _write_payload(".maigo/plan.md"), monkeypatch, capsys
+            ).strip()
+        )
+        assert result["decision"] == "block"
+        assert "scripts/artifact_path.py plan" in result["reason"]
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".maigo/review-rubric.md",
+            ".maigo/pr-comments.md",
+            ".maigo/triage-rubric.md",
+            ".maigo/review.md",
+        ],
+    )
+    def test_all_legacy_kinds_block(
+        self, path: str, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ):
+        result = json.loads(
+            run_silent_hook(_write_payload(path), monkeypatch, capsys).strip()
+        )
+        assert result["decision"] == "block"
+
+    def test_new_identifier_named_path_passes(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ):
+        assert (
+            run_silent_hook(_write_payload(".maigo/plan-main.md"), monkeypatch, capsys)
+            == ""
+        )
+
+    def test_board_md_passes(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ):
+        assert (
+            run_silent_hook(_write_payload(".maigo/board.md"), monkeypatch, capsys)
+            == ""
+        )
+
+    def test_ad_hoc_named_file_passes(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ):
+        assert (
+            run_silent_hook(
+                _write_payload(".maigo/local-model-dispatch-plan.md"),
+                monkeypatch,
+                capsys,
+            )
+            == ""
+        )
+
+    def test_detail_file_under_i_passes(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ):
+        assert (
+            run_silent_hook(_write_payload(".maigo/i/9201.md"), monkeypatch, capsys)
+            == ""
+        )
+
+    def test_edit_tool_also_blocks(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ):
+        result = json.loads(
+            run_silent_hook(
+                _write_payload(".maigo/plan.md", tool_name="Edit"), monkeypatch, capsys
+            ).strip()
+        )
+        assert result["decision"] == "block"
+
+    def test_same_filename_outside_maigo_dir_passes(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ):
+        assert run_silent_hook(_write_payload("plan.md"), monkeypatch, capsys) == ""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {},
+            {"tool_name": "Write", "tool_input": None},
+            {"tool_name": "Write", "tool_input": {}},
+            {"tool_name": "Write", "tool_input": {"file_path": "   "}},
+            {"tool_name": "Write", "tool_input": {"file_path": 42}},
+            {"tool_name": "Bash", "tool_input": {"file_path": ".maigo/plan.md"}},
+        ],
+    )
+    def test_malformed_or_irrelevant_input_fails_open(
+        self,
+        payload: dict,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ):
+        assert run_silent_hook(payload, monkeypatch, capsys) == ""
+
+    def test_non_json_stdin_fails_open(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ):
+        monkeypatch.setattr("sys.stdin", io.StringIO("not json at all"))
+        with pytest.raises(SystemExit) as exc:
+            lac.main()
+        assert exc.value.code == 0
+        assert capsys.readouterr().out == ""
+
+
+class TestBrokenArtifactPathImportFailsOpen:
+    """Regression for the must-fix: `scripts/artifact_path.py` breaking (e.g. a
+    syntax error while a new `kind` is being added) must not take down every
+    Write/Edit in every repo with an uncaught exception."""
+
+    def _reload_with_broken_artifact_path(self):
+        """Simulate `from artifact_path import _KNOWN_KINDS` failing at import
+        time, then reload the hook module so it re-runs its own top-level
+        try/except and falls back to `_KNOWN_KINDS = ()`."""
+        sys.modules.pop("artifact_path", None)
+        sys.modules["artifact_path"] = None  # forces ModuleNotFoundError on import
+        try:
+            importlib.reload(lac)
+        finally:
+            sys.modules.pop("artifact_path", None)
+
+    def _restore(self):
+        """Reload again with the real `artifact_path` module so later tests in
+        this process see the normal, non-empty `_KNOWN_KINDS`."""
+        importlib.reload(lac)
+
+    def test_import_failure_falls_back_to_empty_known_kinds(self):
+        self._reload_with_broken_artifact_path()
+        try:
+            assert lac._KNOWN_KINDS == ()
+            # regex built from an empty alternation must never match a real path
+            assert lac.is_legacy_artifact_path(".maigo/plan.md") is None
+            assert lac.is_legacy_artifact_path(".maigo/review-rubric.md") is None
+        finally:
+            self._restore()
+
+    def test_import_failure_still_fails_open_for_legacy_looking_path(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ):
+        """Before the fix this scenario crashed with an uncaught
+        `ModuleNotFoundError`/`SyntaxError`, exit code 1, no stdout at all.
+        After the fix, main() must still run to completion (exit 0) and the
+        write must not be blocked (no `block` payload) — matching this hook's
+        own documented silent fail-open style."""
+        self._reload_with_broken_artifact_path()
+        try:
+            monkeypatch.setattr(
+                "sys.stdin", io.StringIO(json.dumps(_write_payload(".maigo/plan.md")))
+            )
+            with pytest.raises(SystemExit) as exc:
+                lac.main()
+            assert exc.value.code == 0
+            assert capsys.readouterr().out == ""
+        finally:
+            self._restore()

--- a/tests/test_maigo_dir_catalog.py
+++ b/tests/test_maigo_dir_catalog.py
@@ -1,0 +1,119 @@
+"""Tests for scripts.maigo_dir_catalog — `.maigo/` 頂層檔案分類（唯讀掃描）。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import maigo_dir_catalog as mdc
+
+
+class TestCategorize:
+    def test_identifier_named_known_kind(self):
+        catalog = mdc.categorize(["plan-fix-dag-run-stall.md"])
+        assert catalog.identifier_named == ["plan-fix-dag-run-stall.md"]
+        assert catalog.legacy_fixed_name == []
+        assert catalog.registered_non_artifact == []
+        assert catalog.unregistered == []
+
+    def test_new_review_kind_identifier_named(self):
+        """證明新 kind（review）不用改這支測試就能被正確分類。"""
+        catalog = mdc.categorize(["review-x.md"])
+        assert catalog.identifier_named == ["review-x.md"]
+        assert catalog.unregistered == []
+
+    def test_legacy_fixed_name_known_kind(self):
+        catalog = mdc.categorize(["plan.md"])
+        assert catalog.legacy_fixed_name == ["plan.md"]
+        assert catalog.identifier_named == []
+
+    def test_review_prefix_does_not_swallow_review_rubric(self):
+        """`review` 是 `review-rubric` 的前綴——必須先試最長 kind 才不會誤判。"""
+        catalog = mdc.categorize(
+            ["review-rubric-42.md", "review-rubric.md", "review-42.md", "review.md"]
+        )
+        assert catalog.identifier_named == ["review-42.md", "review-rubric-42.md"]
+        assert catalog.legacy_fixed_name == ["review-rubric.md", "review.md"]
+        assert catalog.unregistered == []
+
+    def test_registered_non_artifact_board(self):
+        catalog = mdc.categorize(["board.md"])
+        assert catalog.registered_non_artifact == ["board.md"]
+        assert catalog.identifier_named == []
+        assert catalog.legacy_fixed_name == []
+        assert catalog.unregistered == []
+
+    def test_unregistered_catch_all(self):
+        catalog = mdc.categorize(
+            ["board-design.md", "index.md", "local-model-dispatch-plan.md"]
+        )
+        assert catalog.unregistered == [
+            "board-design.md",
+            "index.md",
+            "local-model-dispatch-plan.md",
+        ]
+        assert catalog.identifier_named == []
+        assert catalog.legacy_fixed_name == []
+        assert catalog.registered_non_artifact == []
+
+    def test_non_markdown_file_is_unregistered(self):
+        catalog = mdc.categorize(["session-head.json"])
+        assert catalog.unregistered == ["session-head.json"]
+
+    def test_all_four_categories_together(self):
+        catalog = mdc.categorize(
+            [
+                "plan-42.md",
+                "plan.md",
+                "board.md",
+                "board-design.md",
+            ]
+        )
+        assert catalog.identifier_named == ["plan-42.md"]
+        assert catalog.legacy_fixed_name == ["plan.md"]
+        assert catalog.registered_non_artifact == ["board.md"]
+        assert catalog.unregistered == ["board-design.md"]
+
+
+class TestScan:
+    def test_scans_only_top_level_md_files(self, tmp_path: Path):
+        """非 markdown 機器狀態檔（如 session-head.json）與 `i/` 子目錄都不在這支
+        腳本的掃描範圍內——見 `docs/reference/artifacts.md`，它們一行帶過、非
+        agent 面向格式，不用四類分類法。"""
+        maigo_dir = tmp_path / ".maigo"
+        maigo_dir.mkdir()
+        (maigo_dir / "plan-42.md").write_text("# Plan: x\n", encoding="utf-8")
+        (maigo_dir / "board.md").write_text("# Board\n", encoding="utf-8")
+        (maigo_dir / "session-head.json").write_text("{}", encoding="utf-8")
+        nested = maigo_dir / "i"
+        nested.mkdir()
+        (nested / "orphan.md").write_text("# should not be scanned\n", encoding="utf-8")
+
+        catalog = mdc.scan(maigo_dir)
+
+        assert catalog.identifier_named == ["plan-42.md"]
+        assert catalog.registered_non_artifact == ["board.md"]
+        assert catalog.unregistered == []
+
+    def test_missing_dir_returns_empty_catalog(self, tmp_path: Path):
+        catalog = mdc.scan(tmp_path / "does-not-exist")
+        assert catalog.identifier_named == []
+        assert catalog.legacy_fixed_name == []
+        assert catalog.registered_non_artifact == []
+        assert catalog.unregistered == []
+
+
+class TestCli:
+    def test_prints_all_four_section_headers(self, tmp_path: Path, capsys):
+        maigo_dir = tmp_path / ".maigo"
+        maigo_dir.mkdir()
+        (maigo_dir / "plan-42.md").write_text("# Plan: x\n", encoding="utf-8")
+
+        exit_code = mdc.main(["--dir", str(maigo_dir)])
+
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "identifier_named:" in captured.out
+        assert "  plan-42.md" in captured.out
+        assert "legacy_fixed_name:" in captured.out
+        assert "registered_non_artifact:" in captured.out
+        assert "unregistered:" in captured.out

--- a/tests/test_migrate_legacy_artifacts.py
+++ b/tests/test_migrate_legacy_artifacts.py
@@ -1,0 +1,370 @@
+"""Tests for scripts.migrate_legacy_artifacts.
+
+全程只對 `tmp_path` 底下的假 repo 操作，測試不得觸碰任何真實的其他 12 個
+repo——這條規則寫在這裡是提醒之後有人為了「更真實」而把測試指向使用者本機
+真實 repo 路徑：**不要**。
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from scripts import migrate_legacy_artifacts as mla
+from scripts.maigo_dir_catalog import scan
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _make_repo(tmp_path: Path, name: str = "fake-repo") -> Path:
+    repo = tmp_path / name
+    (repo / ".maigo").mkdir(parents=True)
+    return repo
+
+
+class TestPlanMigration:
+    def test_legacy_file_with_h1_uses_slugified_h1_as_identifier(self, tmp_path: Path):
+        repo = _make_repo(tmp_path)
+        (repo / ".maigo" / "plan.md").write_text(
+            "# Fix DAG run stall\n\nbody\n", encoding="utf-8"
+        )
+
+        catalog = scan(repo / ".maigo")
+        actions = mla.plan_migration(repo, catalog)
+
+        assert len(actions) == 1
+        assert actions[0].old_path == ".maigo/plan.md"
+        assert actions[0].new_path == ".maigo/plan-fix-dag-run-stall.md"
+        assert actions[0].disambiguated is False
+
+    def test_legacy_file_missing_h1_falls_back_to_filename_stem(self, tmp_path: Path):
+        repo = _make_repo(tmp_path)
+        (repo / ".maigo" / "review-rubric.md").write_text(
+            "no heading here, just body text\n", encoding="utf-8"
+        )
+
+        catalog = scan(repo / ".maigo")
+        actions = mla.plan_migration(repo, catalog)
+
+        assert len(actions) == 1
+        assert actions[0].old_path == ".maigo/review-rubric.md"
+        # 檔名 stem 剛好等於 kind 本身（"review-rubric"），去疊字後變空字串，
+        # 退到 "unnamed"——不是 "review-rubric-review-rubric.md"（那是本次修
+        # 掉的疊字 bug；見 TestKindStutterRegressions）。
+        assert actions[0].new_path == ".maigo/review-rubric-unnamed.md"
+
+    def test_new_style_named_file_is_not_migrated(self, tmp_path: Path):
+        repo = _make_repo(tmp_path)
+        (repo / ".maigo" / "plan-x.md").write_text("# Plan: X\n", encoding="utf-8")
+
+        catalog = scan(repo / ".maigo")
+        actions = mla.plan_migration(repo, catalog)
+
+        assert actions == []
+
+    def test_ad_hoc_named_file_is_not_migrated(self, tmp_path: Path):
+        repo = _make_repo(tmp_path)
+        (repo / ".maigo" / "local-model-dispatch-plan.md").write_text(
+            "# Local model dispatch\n", encoding="utf-8"
+        )
+
+        catalog = scan(repo / ".maigo")
+        actions = mla.plan_migration(repo, catalog)
+
+        assert actions == []
+
+    def test_target_conflict_with_existing_new_style_file_gets_suffix(
+        self, tmp_path: Path
+    ):
+        repo = _make_repo(tmp_path)
+        (repo / ".maigo" / "plan.md").write_text(
+            "# Fix DAG run stall\n", encoding="utf-8"
+        )
+        # 該 repo 已有一份新命名檔案，恰好撞到遷移後會算出的目標檔名。
+        (repo / ".maigo" / "plan-fix-dag-run-stall.md").write_text(
+            "# Fix DAG run stall (already migrated by someone else)\n",
+            encoding="utf-8",
+        )
+
+        catalog = scan(repo / ".maigo")
+        actions = mla.plan_migration(repo, catalog)
+
+        assert len(actions) == 1
+        assert actions[0].new_path == ".maigo/plan-fix-dag-run-stall-2.md"
+        assert actions[0].disambiguated is True
+
+    def test_two_legacy_files_colliding_on_same_h1_both_disambiguate(
+        self, tmp_path: Path
+    ):
+        # 兩份不同 kind 的舊檔理論上不會撞名（kind 前綴不同），但同 kind 不會發生
+        # （每個 kind 只有一份舊固定檔名）；這裡改用「已存在的第三方檔案」模擬
+        # 連續撞名，驗證尾碼會遞增而不是卡在 -2。
+        repo = _make_repo(tmp_path)
+        (repo / ".maigo" / "plan.md").write_text("# X\n", encoding="utf-8")
+        (repo / ".maigo" / "plan-x.md").write_text("taken\n", encoding="utf-8")
+        (repo / ".maigo" / "plan-x-2.md").write_text("also taken\n", encoding="utf-8")
+
+        catalog = scan(repo / ".maigo")
+        actions = mla.plan_migration(repo, catalog)
+
+        assert actions[0].new_path == ".maigo/plan-x-3.md"
+        assert actions[0].disambiguated is True
+
+    def test_no_legacy_files_returns_empty_list(self, tmp_path: Path):
+        repo = _make_repo(tmp_path)
+        (repo / ".maigo" / "board.md").write_text("# Work Board\n", encoding="utf-8")
+
+        catalog = scan(repo / ".maigo")
+        assert mla.plan_migration(repo, catalog) == []
+
+
+class TestKindStutterRegressions:
+    """回歸樣本：13 個真實 repo 跑 dry-run 時，11 筆遷移裡有 8 筆撞到
+    `<kind>-<kind>-...` 疊字檔名。真實 H1 內容無法取得（不讀真實 repo），
+    這裡用會 slugify 出同樣疊字前綴＋同樣截斷邊界情境的合成 H1 重建每一筆，
+    逐一驗證修好後不再疊字、且截斷（真的命中 40 字元上限時）會退到完整的
+    `-` 分段邊界。
+    """
+
+    def _migrate_one(
+        self, tmp_path: Path, legacy_name: str, h1: str, repo_name: str | None = None
+    ) -> str:
+        # 預設用 h1 的 hash 湊出唯一 repo 名，避免同一個 tmp_path 底下多次
+        # 呼叫（例如批次跑全部 8 筆樣本的測試）撞到同名目錄。
+        unique = repo_name or f"{legacy_name.replace('.', '-')}-{abs(hash(h1)) % 10000}"
+        repo = _make_repo(tmp_path, unique)
+        (repo / ".maigo" / legacy_name).write_text(h1 + "\n", encoding="utf-8")
+        catalog = scan(repo / ".maigo")
+        actions = mla.plan_migration(repo, catalog)
+        assert len(actions) == 1
+        return actions[0].new_path
+
+    def test_main_blog_plan_no_stutter(self, tmp_path: Path):
+        new_path = self._migrate_one(
+            tmp_path, "plan.md", "# Plan: Stats — Pelican stat dual mode (EN)"
+        )
+        assert new_path == ".maigo/plan-stats-pelican-stat-dual-mode-en.md"
+
+    def test_pelican_osm_plan_no_stutter(self, tmp_path: Path):
+        new_path = self._migrate_one(
+            tmp_path, "plan.md", "# Plan: Emoji icon pin for place markers"
+        )
+        assert new_path == ".maigo/plan-emoji-icon-pin-for-place-markers.md"
+
+    def test_ring_plan_no_stutter(self, tmp_path: Path):
+        new_path = self._migrate_one(tmp_path, "plan.md", "# Plan: Ring kitty focuser")
+        assert new_path == ".maigo/plan-ring-kitty-focuser.md"
+
+    def test_attila_review_rubric_no_stutter_and_truncation_lands_on_boundary(
+        self, tmp_path: Path
+    ):
+        new_path = self._migrate_one(
+            tmp_path,
+            "review-rubric.md",
+            "# Review rubric — feat: pagination and modernization",
+        )
+        assert new_path == ".maigo/review-rubric-feat-pagination-and.md"
+        # 截斷邊界驗證：不能落在字中間（例如疊字修掉之前真實遷移出來的
+        # "...-and-modern.md" 就是這樣被 40 字元上限硬切出來的）。
+        stem = Path(new_path).stem
+        assert not stem.endswith("-modern")
+
+    def test_airflow_pr_comments_ack_channel_no_stutter_and_boundary(
+        self, tmp_path: Path
+    ):
+        new_path = self._migrate_one(
+            tmp_path,
+            "pr-comments.md",
+            "# PR comments — add producer-side ack channel",
+        )
+        assert new_path == ".maigo/pr-comments-add-producer-side-ack.md"
+        assert not Path(new_path).stem.endswith("-channe")
+
+    def test_airflow_review_rubric_no_stutter_and_boundary(self, tmp_path: Path):
+        new_path = self._migrate_one(
+            tmp_path,
+            "review-rubric.md",
+            "# Review rubric — fix N+1 queries in triggerer",
+        )
+        assert new_path == ".maigo/review-rubric-fix-n-1-queries-in.md"
+        assert not Path(new_path).stem.endswith("-trigger")
+
+    def test_pycontw_blog_plan_no_stutter(self, tmp_path: Path):
+        new_path = self._migrate_one(
+            tmp_path,
+            "plan.md",
+            "# Plan: create_post slug — PR #224 review c2",
+        )
+        assert new_path == ".maigo/plan-create_post-slug-pr-224-review-c2.md"
+
+    def test_pycontw_blog_pr_comments_no_stutter_and_boundary(self, tmp_path: Path):
+        new_path = self._migrate_one(
+            tmp_path,
+            "pr-comments.md",
+            "# PR comments — fix create-post and dev tooling",
+        )
+        assert new_path == ".maigo/pr-comments-fix-create-post-and-dev.md"
+        assert not Path(new_path).stem.endswith("-tool")
+
+    def test_no_new_path_contains_kind_kind_stutter(self, tmp_path: Path):
+        """所有 8 筆樣本共通斷言：新檔名不得含 `<kind>-<kind>-` 疊字。"""
+        samples = [
+            ("plan.md", "# Plan: Stats — Pelican stat dual mode (EN)"),
+            ("plan.md", "# Plan: Emoji icon pin for place markers"),
+            ("plan.md", "# Plan: Ring kitty focuser"),
+            (
+                "review-rubric.md",
+                "# Review rubric — feat: pagination and modernization",
+            ),
+            ("pr-comments.md", "# PR comments — add producer-side ack channel"),
+            ("review-rubric.md", "# Review rubric — fix N+1 queries in triggerer"),
+            ("plan.md", "# Plan: create_post slug — PR #224 review c2"),
+            ("pr-comments.md", "# PR comments — fix create-post and dev tooling"),
+        ]
+        for i, (legacy_name, h1) in enumerate(samples):
+            new_path = self._migrate_one(tmp_path, legacy_name, h1)
+            kind = legacy_name[: -len(".md")]
+            assert f"{kind}-{kind}-" not in new_path, (i, legacy_name, h1, new_path)
+
+
+class TestApplyMigration:
+    def test_apply_renames_file_and_preserves_content(self, tmp_path: Path):
+        repo = _make_repo(tmp_path)
+        old = repo / ".maigo" / "plan.md"
+        old.write_text("# Fix DAG run stall\n\nsome body content\n", encoding="utf-8")
+        original_hash = _sha(old)
+
+        catalog = scan(repo / ".maigo")
+        actions = mla.plan_migration(repo, catalog)
+        mla.apply_migration(repo, actions)
+
+        new = repo / actions[0].new_path
+        assert not old.exists()
+        assert new.exists()
+        assert _sha(new) == original_hash
+
+
+class TestCli:
+    def test_dry_run_does_not_touch_any_file(self, tmp_path: Path, capsys):
+        repo = _make_repo(tmp_path)
+        old = repo / ".maigo" / "plan.md"
+        old.write_text("# Fix DAG run stall\n", encoding="utf-8")
+        original_hash = _sha(old)
+
+        exit_code = mla.main([str(repo)])
+
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert f"{repo} :: .maigo/plan.md -> .maigo/plan-fix-dag-run-stall.md" in (
+            captured.out
+        )
+        assert old.exists()
+        assert _sha(old) == original_hash
+        assert not (repo / ".maigo" / "plan-fix-dag-run-stall.md").exists()
+
+    def test_apply_flag_actually_renames(self, tmp_path: Path, capsys):
+        repo = _make_repo(tmp_path)
+        old = repo / ".maigo" / "plan.md"
+        old.write_text("# Fix DAG run stall\n", encoding="utf-8")
+
+        exit_code = mla.main([str(repo), "--apply"])
+
+        assert exit_code == 0
+        assert not old.exists()
+        assert (repo / ".maigo" / "plan-fix-dag-run-stall.md").exists()
+
+    def test_rerun_after_apply_is_idempotent_and_reports_nothing_to_migrate(
+        self, tmp_path: Path, capsys
+    ):
+        repo = _make_repo(tmp_path)
+        old = repo / ".maigo" / "plan.md"
+        old.write_text("# Fix DAG run stall\n", encoding="utf-8")
+
+        mla.main([str(repo), "--apply"])
+        capsys.readouterr()  # drain first run's output
+
+        exit_code = mla.main([str(repo), "--apply"])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert f"{repo} :: (nothing to migrate)" in captured.out
+        assert (repo / ".maigo" / "plan-fix-dag-run-stall.md").exists()
+
+    def test_repo_list_file_is_read_when_no_positional_repos_given(
+        self, tmp_path: Path, capsys
+    ):
+        repo_a = _make_repo(tmp_path, "repo-a")
+        repo_b = _make_repo(tmp_path, "repo-b")
+        (repo_a / ".maigo" / "plan.md").write_text("# Plan: A\n", encoding="utf-8")
+        (repo_b / ".maigo" / "plan.md").write_text("# Plan: B\n", encoding="utf-8")
+
+        repo_list = tmp_path / "repos.txt"
+        repo_list.write_text(
+            f"# comment line, ignored\n\n{repo_a}\n{repo_b}\n", encoding="utf-8"
+        )
+
+        exit_code = mla.main(["--repo-list", str(repo_list)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert str(repo_a) in captured.out
+        assert str(repo_b) in captured.out
+        # dry-run: repo-list 讀取本身唯讀，任何一邊都沒被真的搬動
+        assert (repo_a / ".maigo" / "plan.md").exists()
+        assert (repo_b / ".maigo" / "plan.md").exists()
+
+    def test_repo_list_missing_file_is_not_a_silent_noop(self, tmp_path: Path, capsys):
+        missing = tmp_path / "nope" / "repos.txt"
+
+        exit_code = mla.main(["--repo-list", str(missing)])
+        captured = capsys.readouterr()
+
+        assert exit_code != 0
+        assert captured.out == ""  # 不能印出跟「真的沒東西要遷移」一樣的輸出
+        assert str(missing) in captured.err
+        assert "not found" in captured.err or "unreadable" in captured.err
+
+    def test_repo_list_empty_file_is_not_a_silent_noop(self, tmp_path: Path, capsys):
+        repo_list = tmp_path / "repos.txt"
+        repo_list.write_text("", encoding="utf-8")
+
+        exit_code = mla.main(["--repo-list", str(repo_list)])
+        captured = capsys.readouterr()
+
+        assert exit_code != 0
+        assert captured.out == ""
+        assert str(repo_list) in captured.err
+
+    def test_repo_list_all_comments_is_not_a_silent_noop(self, tmp_path: Path, capsys):
+        repo_list = tmp_path / "repos.txt"
+        repo_list.write_text("# just a comment\n\n# another\n", encoding="utf-8")
+
+        exit_code = mla.main(["--repo-list", str(repo_list)])
+        captured = capsys.readouterr()
+
+        assert exit_code != 0
+        assert captured.out == ""
+        assert str(repo_list) in captured.err
+
+    def test_repo_list_with_nonexistent_repo_path_is_skipped_with_reason(
+        self, tmp_path: Path, capsys
+    ):
+        real_repo = _make_repo(tmp_path, "real-repo")
+        (real_repo / ".maigo" / "plan.md").write_text(
+            "# Plan: Real\n", encoding="utf-8"
+        )
+        fake_repo = tmp_path / "does-not-exist"
+
+        repo_list = tmp_path / "repos.txt"
+        repo_list.write_text(f"{fake_repo}\n{real_repo}\n", encoding="utf-8")
+
+        exit_code = mla.main(["--repo-list", str(repo_list)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert f"{fake_repo} :: skipped" in captured.out
+        assert str(real_repo) in captured.out
+        # 真的存在的 repo 仍照常算出遷移計畫，不受前一筆缺路徑影響
+        assert "plan-real.md" in captured.out

--- a/tests/test_worktree_path.py
+++ b/tests/test_worktree_path.py
@@ -1,0 +1,71 @@
+"""Tests for scripts.worktree_path — sibling worktree path + branch name computation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import worktree_path as wp
+
+
+class TestSlugReuse:
+    """跟 tests/test_artifact_path.py 的 TestSlugify 同幾個案例，確認同一份正則邏輯。"""
+
+    def test_lowercases_and_replaces_invalid_chars(self, tmp_path: Path):
+        location = wp.compute_worktree_location(
+            "maigo", "Fix/DAG Run_Stall!!", cwd=tmp_path
+        )
+        assert location.branch == "fix-dag-run_stall"
+
+    def test_cjk_only_topic_falls_back_to_unnamed(self, tmp_path: Path):
+        location = wp.compute_worktree_location("maigo", "繁體中文字", cwd=tmp_path)
+        assert location.branch == "unnamed"
+
+    def test_empty_topic_falls_back_to_unnamed(self, tmp_path: Path):
+        location = wp.compute_worktree_location("maigo", "", cwd=tmp_path)
+        assert location.branch == "unnamed"
+
+
+class TestPathComposition:
+    def test_path_is_sibling_of_cwd_named_repo_hyphen_slug(self, tmp_path: Path):
+        checkout = tmp_path / "workspaces" / "maigo"
+        checkout.mkdir(parents=True)
+
+        location = wp.compute_worktree_location(
+            "maigo", "Fix DAG run stall", cwd=checkout
+        )
+
+        assert location.path == str(tmp_path / "workspaces" / "maigo-fix-dag-run-stall")
+        assert location.branch == "fix-dag-run-stall"
+
+    def test_path_does_not_hardcode_any_fixed_root(self, tmp_path: Path):
+        checkout_a = tmp_path / "somewhere" / "maigo"
+        checkout_a.mkdir(parents=True)
+        checkout_b = tmp_path / "elsewhere" / "deep" / "maigo"
+        checkout_b.mkdir(parents=True)
+
+        location_a = wp.compute_worktree_location("maigo", "x", cwd=checkout_a)
+        location_b = wp.compute_worktree_location("maigo", "x", cwd=checkout_b)
+
+        assert location_a.path == str(tmp_path / "somewhere" / "maigo-x")
+        assert location_b.path == str(tmp_path / "elsewhere" / "deep" / "maigo-x")
+        assert location_a.path != location_b.path
+        assert "worktrees" not in location_a.path
+        assert "worktrees" not in location_b.path
+
+
+class TestCli:
+    def test_prints_path_and_branch(self, tmp_path: Path, capsys):
+        checkout = tmp_path / "maigo"
+        checkout.mkdir()
+
+        exit_code = wp.main(
+            ["--repo", "maigo", "--topic", "Fix DAG run stall", "--cwd", str(checkout)]
+        )
+
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert (
+            captured.out.splitlines()[0]
+            == f"path: {tmp_path / 'maigo-fix-dag-run-stall'}"
+        )
+        assert captured.out.splitlines()[1] == "branch: fix-dag-run-stall"


### PR DESCRIPTION
Add maigo_dir_catalog.py, a read-only scanner that sorts top-level
.maigo/ markdown into managed names, legacy fixed names, registered
non-artifacts and unregistered leftovers. It judges by a whitelist of
what belongs rather than a blacklist of known junk, so the next stray
file is caught too, and it reads the kind list from artifact_path.py
instead of keeping a second copy.

/maigo:doctor now reports the catalog, and docs/reference/artifacts.md
documents what each file under .maigo/ is and which code owns it.