### PR TITLE
fix: verify quick tasks across agent hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ Codex session 有提供多 agent 工具時，Maigo 會依 command 進行分工�
 只要 plugin 載入就生效，使用者不用設定：
 
 - **PostToolUse** — 本機記錄 foreground subagent 回傳的 token usage metadata；不估算、不額外呼叫模型
-- **TeammateIdle** — agent 輸出不符規格（如 Soyo 沒下 verdict、Taki 沒貼 exit code）就 block
+- **SubagentStop** — agent 輸出不符規格（如 🟡 Soyo 沒下 verdict、🟣 Taki 沒貼 exit code）就 block
 - **Stop** — 任務宣告完成前自動偵測專案類型跑 test，並在成功訊息附上本 session 的一行 token 摘要
 
 → 完整擋下條件、設定檔（`.claude/skip-test-verification` 等）：[docs/reference/hooks.md](docs/reference/hooks.md)
 
 Codex manifest 不會安裝這些 Claude Code lifecycle hooks；`command-router` 會要求明確跑完
-command 裡的 review 與 verification 步驟，但不宣稱 TeammateIdle / Stop hook 已強制擋下。
+command 裡的 review 與 verification 步驟，但不宣稱 SubagentStop / Stop hook 已強制擋下。
 
 ## 產出檔案
 
@@ -129,7 +129,7 @@ Artefact 在本機保留直到手動清除。SessionStart hook（`repo_detect`�
 - [Getting Started](docs/guides/getting-started.md) — 第一次裝 Maigo 的 5 分鐘入門
 - [Commands reference](docs/reference/commands.md) — 每個命令的完整流程、合流邏輯、場景對照
 - [Memory reference](docs/reference/memory.md) — 跨專案記憶層的 storage / schema / 讀寫
-- [Hooks reference](docs/reference/hooks.md) — SessionStart / TeammateIdle / Stop hook 完整行為與設定
+- [Hooks reference](docs/reference/hooks.md) — SessionStart / SubagentStop / Stop hook 完整行為與設定
 - [Skills reference](docs/reference/skills.md) — skill 機制與完整 catalog（`strict-review`、`teammate-flow`、`commit-message`、`doc-link-convention`、`copyable-deliverable`、`failure-handling` 等）
 - [Agents reference](docs/reference/agents.md) — 五位 agent 的 model tier 選擇邏輯
 - [Contributing](docs/guides/contributing.md) — 修 Maigo 本身的設定、原則、validator

--- a/commands/address-comments.md
+++ b/commands/address-comments.md
@@ -149,7 +149,7 @@ triage 檔全欄位骨架（selected 意見 + work items）與路由判斷表（
 - 每個 work item 開跑前把 triage 檔該項 `Status` 改 `in-progress`，完成改 `done`。
 - 被選 route 的失敗處理、Soyo 擋下、Taki 紅、**2** 次同條卡關才停下找使用者——依 [`skills/failure-handling`](https://github.com/Lee-W/maigo/blob/main/skills/failure-handling/SKILL.md)，address-comments 不另立規則。
 - 某個 work item 卡死（依該 route 規則停下找使用者）→ 該項標 `blocked`，**其餘 work item 照常繼續**，最後在 summary 點出卡住的那項。
-- **Commit 政策覆寫**：多個 work item 共享 working tree——若不 commit，後一個 work item 的 Anon / Soyo 會看到前一個的未 commit 改動，污染 diff、混淆 review 焦點。**因此覆寫 inner route 的「不自動 `git commit`」預設**（`/maigo:quick` 流程步驟 4、`/maigo:go` / `/maigo:team` 的 finale 規則）：每個 work item 完成、Soyo 過、Stop hook 綠後，orchestrator 依步驟 4 使用者選擇的 commit 格式落地：
+- **Commit 政策覆寫**：多個 work item 共享 working tree——若不 commit，後一個 work item 的 Anon / Soyo 會看到前一個的未 commit 改動，污染 diff、混淆 review 焦點。**因此覆寫 inner route 的「不自動 `git commit`」預設**（`/maigo:quick` 流程步驟 4、`/maigo:go` / `/maigo:team` 的 finale 規則）：每個 work item 完成、🟡 Soyo 過、被選 route 的顯式驗證通過後，orchestrator 依步驟 4 使用者選擇的 commit 格式落地：
 
   - **各自獨立 commit（預設）**：直接用 inner route 草擬的 commit message 落地。subject 格式照 [`skills/commit-message`](https://github.com/Lee-W/maigo/blob/main/skills/commit-message/SKILL.md) 的偵測決定，**不預設 CC**——target repo 的成文慣例優先於 skill 預設。
   - **fixup! commit（使用者在步驟 4 選擇）**：subject 改為 `fixup! <原 PR 主題>`，讓 `git rebase --autosquash` 接得起來。

--- a/commands/describe-pr.md
+++ b/commands/describe-pr.md
@@ -90,7 +90,7 @@ orchestrator 用 Task tool 啟動燈，把前置 bundle 交給她。燈：
 ## 失敗處理
 
 - base / branch 的問題（找不到 base、HEAD == base、無 commit）在**步驟 1 前置**就判掉，不啟動燈。
-- 燈回的草稿被 TeammateIdle hook 擋下（缺 `## Loaded memory entries`，或 PR 草稿缺 `## Suggested PR title` / `## Suggested PR description`）→ orchestrator 把擋下原因完整轉給燈重產。
+- 🩵 燈回的草稿被 SubagentStop hook 擋下（缺 `## Loaded memory entries`，或 PR 草稿缺 `## Suggested PR title` / `## Suggested PR description`）→ orchestrator 把擋下原因完整轉給 🩵 燈重產。
 
 ## Orchestrator 守則
 

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -1,5 +1,5 @@
 ---
-description: 輕量任務入口。Orchestrator 直接呼叫 Anon 做小改動，跳過 Raana / Tomori，Anon 做完跑輕量 Soyo（4 項 checklist subset）。Stop hook 自動兜底測試。
+description: 輕量任務入口。Anon 做小改動、Soyo 跑 4 項 checklist subset，再顯式執行驗證。支援沒有 lifecycle hooks 或 subagents 的環境。
 ---
 
 <!-- mkdocs-include-start -->
@@ -8,7 +8,7 @@ description: 輕量任務入口。Orchestrator 直接呼叫 Anon 做小改動，
 
 「這個小東西改一下」級別的任務。跳過 Raana 探索 / Tomori 寫 plan 的 overhead，
 orchestrator 直接呼叫 Anon 動手，做完跑 Soyo 輕量 review（9 項 → 4 項）。
-Test 不顯式喊 Taki——stop hook 在任務完成前自動跑測試兜底。
+測試由 orchestrator 顯式呼叫共用驗證 CLI，不需另外啟動 🟣 立希。
 
 ## 使用
 
@@ -35,15 +35,44 @@ Test 不顯式喊 Taki——stop hook 在任務完成前自動跑測試兜底。
    - Anon 自己看周邊 1-2 個檔抓慣例，不做大範圍探索
    - 不寫 plan.md
 2. **爽世 (Soyo)** — 輕量 review，只跑 9 項中的 4 項。「這裡這樣寫，應該不對。」
-3. **Stop hook 自動跑 test** — 不顯式呼叫 Taki；成功訊息會附本 session 的一行 token usage
-4. **Orchestrator** — Stop hook 綠後，若還有未 commit 的本次變更，依 [`skills/commit-message`](https://github.com/Lee-W/maigo/blob/main/skills/commit-message/SKILL.md) 草擬一段 commit message 附在 final summary。格式照該 skill 的偵測跑，**不預設 CC**——target repo 的成文慣例優先（例：apache/airflow 明禁 CC 前綴並有 commit-msg hook 擋）。**不自動跑 git commit**。接著依 [`skills/pr-sync-check`](https://github.com/Lee-W/maigo/blob/main/skills/pr-sync-check/SKILL.md) 核對當前 branch 若已開 PR，其 title/description 是否仍符合現在的實際改動；沒有對應 PR 就跳過，不算失敗。
+3. **Orchestrator 顯式驗證** — 🟡 爽世 APPROVED 後，依下節執行驗證 CLI，保存 command、cwd、exit code 與 output。修過檔案就重跑，不能沿用修改前的結果。
+4. **Orchestrator** — 驗證 `passed` 後，若還有未 commit 的本次變更，依 [`skills/commit-message`](https://github.com/Lee-W/maigo/blob/main/skills/commit-message/SKILL.md) 草擬一段 commit message 附在 final summary。格式照該 skill 的偵測跑，**不預設 CC**——target repo 的成文慣例優先（例：apache/airflow 明禁 CC 前綴並有 commit-msg hook 擋）。**不自動跑 git commit**。接著依 [`skills/pr-sync-check`](https://github.com/Lee-W/maigo/blob/main/skills/pr-sync-check/SKILL.md) 核對當前 branch 若已開 PR，其 title/description 是否仍符合現在的實際改動；沒有對應 PR 就跳過，不算失敗。
+
+### 顯式驗證契約（所有宿主共用）
+
+先定位這份 command 所屬的 Maigo plugin root，將 `<maigo-root>` 換成它的絕對路徑；
+`<project-cwd>` 是本次實作的 repo／worktree 絕對路徑。不要把 target repo 當成 plugin root。
+
+```bash
+python3 <maigo-root>/scripts/verify_task.py --cwd <project-cwd>
+```
+
+可用 `--command '<實際測試指令>'` 指定任務需要的驗證；參數以 argv 解析，不執行 shell。
+未指定時沿用 `.claude/test-command` 與既有 runner 偵測，設定格式見
+[Hooks reference](../docs/reference/hooks.md#explicit-task-verification)。
+
+| JSON status | CLI exit | 後續動作 |
+|---|---|---|
+| `passed` | 0 | 可進步驟 4；仍須 🟡 爽世 APPROVED |
+| `failed` | 1 | 把實際 output 給 🎀 愛音修復，再 review／驗證 |
+| `unavailable` | 2 | 回報缺少 runner、設定或環境；補齊後重跑，不宣稱驗證通過 |
+| `skipped` | 3 | 附既有設定的 skip reason；標示未驗證 |
+| `known_failures` | 4 | 附已知失敗與實際非零 exit code；不標示全綠 |
+
+後兩者只能依使用者**已授權**的例外政策收尾；沒有對應授權時回報待決定，不能自行把狀態改成 `passed`。
+若另需 lint、type check 或人工驗證，照 target repo 要求補跑；CLI 的 `passed` 只證明該次 command 成功。
+
+沒有 subagents 時，由主 agent 依 🎀 愛音 → 🟡 爽世的順序執行，明示共用 context；
+有 fresh context 能力時優先用獨立審查。可以只使用同一個模型，無須有商用升級檔位。
+沒有 hooks 時，這是命令要求的顯式檢查，不能宣稱宿主已機器強制。
+Claude Code 的 Stop hook 保留額外檢查，不能用「之後 hook 會跑」取代步驟 3。
 
 ## Soyo 輕量 checklist（9 項 → 4 項）
 
 | 項 | 跑？ |
 |---|------|
 | 1. acceptance match | ✅ |
-| 2. evidence per function | ❌ skip（stop hook 跑 test 兜底） |
+| 2. evidence per function | ❌ skip（步驟 3 顯式跑 test） |
 | 3. edge case coverage | ❌ skip |
 | 4. convention conformance | ✅ |
 | 5. no unsafe pattern | ✅ |
@@ -54,7 +83,7 @@ Test 不顯式喊 Taki——stop hook 在任務完成前自動跑測試兜底。
 
 合計 4 項：1 / 4 / 5 / 7。
 
-orchestrator 啟動 Soyo 時 prompt 必須明示「mode=quick」與上述 subset。Soyo 輸出 checklist 表時 subset 內項照常 `[x]` / `[ ]`，subset 外項標 `[—]` 附 reason `skipped by mode=quick`。
+orchestrator 啟動 🟡 Soyo 時 prompt 必須明示「mode=quick」與上述 subset。輸出 `## Checklist` 段，依序保留完整 9 項；subset 內項照常 `[x]` / `[ ]`，subset 外項標 `[—]` 附 reason `skipped by mode=quick`。
 
 詳細「為什麼這 4 項」與「為什麼略掉那 5 項」見
 [`skills/strict-review/SKILL.md`](https://github.com/Lee-W/maigo/blob/main/skills/strict-review/SKILL.md)
@@ -67,9 +96,9 @@ orchestrator 啟動 Soyo 時 prompt 必須明示「mode=quick」與上述 subset
 跟 `/maigo:go` 同——把 must-fix 完整給 Anon、修完重 review、**2** 次同條才停下找使用者。
 詳見 [`skills/failure-handling`](https://github.com/Lee-W/maigo/blob/main/skills/failure-handling/SKILL.md)。
 
-### Stop hook 測試紅
+### 顯式驗證失敗
 
-stop hook 會把 failure 自動顯示給使用者。orchestrator 接到後把錯誤完整貼給 Anon 重修。
+orchestrator 讀取驗證 CLI 的 JSON status 與 output，依上述契約處理；失敗內容完整交給 🎀 愛音。
 
 ## Memory propose confirm flow
 
@@ -82,7 +111,7 @@ stop hook 會把 failure 自動顯示給使用者。orchestrator 接到後把錯
 - **不能跳過 Soyo**——quick-fix 砍的是 stage 數量（無 Raana / Tomori / 顯式 Taki），不是 review 本身
 - **不能改 Soyo 的 4 項 subset 為更少**——這 4 項是硬底線
 - **不能因為「使用者說 quick-fix」就放寬 must-fix 標準**——subset 內的項仍照 strict-review 規則
-- **不要自己 review / 不要自己實作**——分別交給 Anon 與 Soyo Task
+- **有 subagents 時分工**——實作與 review 分別交給 🎀 愛音與 🟡 爽世；無此能力時依顯式驗證契約執行 fallback
 - fence tracking 與 `## Memory propose` 偵測規則依 [`skills/memory-propose-confirm`](https://github.com/Lee-W/maigo/blob/main/skills/memory-propose-confirm/SKILL.md)
 
 ## 與 `/maigo:go` / `/maigo:team` 的差異
@@ -93,8 +122,8 @@ stop hook 會把 failure 自動顯示給使用者。orchestrator 接到後把錯
 | Tomori plan | ❌ skip | ✅ | ✅ |
 | Anon 實作 | ✅ | ✅ | ✅ |
 | Soyo review | ✅ 輕量（4 項） | ✅ 完整（9 項） | ✅ 完整（9 項） |
-| Taki 顯式 | ❌（stop hook 兜底） | ✅ | ✅（並行） |
+| 🟣 Taki 顯式 | ❌（orchestrator 顯式執行 CLI） | ✅ | ✅（並行） |
 
-/maigo:go 與 /maigo:team 共用 [`skills/teammate-flow`](https://github.com/Lee-W/maigo/blob/main/skills/teammate-flow/SKILL.md)；/maigo:quick 流程結構不同（無 Raana / Tomori、Soyo subset、Stop hook 兜底測試），所以獨立。
+/maigo:go 與 /maigo:team 共用 [`skills/teammate-flow`](https://github.com/Lee-W/maigo/blob/main/skills/teammate-flow/SKILL.md)；/maigo:quick 採 🎀 愛音實作、🟡 爽世 subset 與 orchestrator 顯式驗證，所以獨立。
 
 → 場景對照、其他命令：[Commands reference](https://github.com/Lee-W/maigo/blob/main/docs/reference/commands.md)

--- a/docs/commands/describe-pr.md
+++ b/docs/commands/describe-pr.md
@@ -4,7 +4,7 @@ flowchart TD
     Prep --> Gate{base 有效?<br/>HEAD≠base 且有 commit?}
     Gate -- 否 --> Stop([印訊息結束])
     Gate -- 是 --> Tomori[燈 Tomori<br/>套 github-title-description<br/>產 PR title + description]
-    Tomori --> Hook{TeammateIdle hook<br/>草稿結構齊全?}
+    Tomori --> Hook{SubagentStop hook<br/>草稿結構齊全?}
     Hook -- 否 --> Tomori
     Hook -- 是 --> Finish[Orchestrator 收尾<br/>印草稿 + gh pr create 提示]
     Finish --> Done([完成])

--- a/docs/commands/quick.md
+++ b/docs/commands/quick.md
@@ -9,10 +9,11 @@ flowchart TD
     Anon --> Soyo[爽世 Soyo<br/>輕量 review<br/>4 項 subset]
     Soyo --> SoyoVerdict{APPROVED?}
     SoyoVerdict -- BLOCKED --> Anon
-    SoyoVerdict -- APPROVED --> StopHook([Stop hook<br/>自動跑 test])
-    StopHook --> HookVerdict{test 綠?}
-    HookVerdict -- FAIL --> Anon
-    HookVerdict -- PASS --> Commit[Orchestrator<br/>草擬 commit msg]
+    SoyoVerdict -- APPROVED --> Verification[Orchestrator<br/>verify_task.py]
+    Verification --> HookVerdict{status?}
+    HookVerdict -- failed --> Anon
+    HookVerdict -- passed --> Commit[Orchestrator<br/>草擬 commit msg]
+    HookVerdict -- unavailable / skipped / known_failures --> Unverified([回報未通過驗證與原因])
     Commit --> Done([完成])
 
     classDef raana fill:#6EEB83,stroke:#333,color:#000

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -113,9 +113,9 @@ maigo/
 ├── skills/                          # 跨 agent/command 共用的 process
 │   └── strict-review/ / teammate-flow/ / commit-message/ / failure-handling/ / memory-loading/ / memory-propose-confirm/ / narration/ / pr-context-cache/ / github-title-description/ / doc-link-convention/ / airflow-aware/ / commitizen-aware/
 ├── hooks/
-│   ├── hooks.json                   # 註冊 SessionStart + TeammateIdle + Stop
+│   ├── hooks.json                   # 註冊 SessionStart + SubagentStop + Stop
 │   ├── repo_detect.py               # SessionStart：偵測 repo 自動載 domain skill
-│   ├── teammate_quality_check.py    # TeammateIdle：agent 輸出規格檢查
+│   ├── teammate_quality_check.py    # SubagentStop：agent 輸出規格檢查
 │   ├── verify_completion.py         # Stop：任務宣告完成前強制跑 test
 │   ├── _hook_io.py                  # 共用 emit() payload
 │   └── _retry_log.py                # 共用 JSONL retry-log（Soyo must-fix / Taki test 失敗）

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ claude --plugin-dir /path/to/maigo
 
 - [Getting Started](guides/getting-started.md) — 第一次裝 Maigo 的 5 分鐘入門
 - [Commands reference](reference/commands.md) — 每個命令的完整流程、合流邏輯、場景對照
-- [Hooks reference](reference/hooks.md) — SessionStart / TeammateIdle / Stop hook 行為與設定
+- [Hooks reference](reference/hooks.md) — SessionStart / SubagentStop / Stop hook 行為與設定
 - [Skills reference](reference/skills.md) — skill 機制與目前 catalog
 - [Agents reference](reference/agents.md) — 五位 agent 的 model tier 選擇邏輯
 - [Contributing](guides/contributing.md) — 修 Maigo 本身的設定與原則

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -61,7 +61,7 @@ Maigo 提供十五個命令，所有命令的 source-of-truth 是 `commands/*.md
 
 ## `/maigo:quick` — 輕量任務入口
 
-跳過 Raana / Tomori，orchestrator 直接呼叫 Anon。Anon 做完跑 Soyo 輕量 review（9 項 → 4 項），test 由 stop hook 兜底。
+跳過 Raana / Tomori，orchestrator 直接呼叫 Anon。Anon 做完跑 Soyo 輕量 review（9 項 → 4 項），orchestrator 顯式執行驗證 CLI。
 
 ```
 /maigo:quick <小任務描述>
@@ -71,7 +71,7 @@ Maigo 提供十五個命令，所有命令的 source-of-truth 是 `commands/*.md
 
 跑：1（acceptance match）+ 4（convention）+ 5（safety）+ 7（no TODO evasion）
 
-略：2（evidence，由 stop hook 兜底）/ 3（edge case）/ 6（magic）/ 8（bloat）/ 9（completeness theatre）
+略：2（evidence，由顯式測試提供）/ 3（edge case）/ 6（magic）/ 8（bloat）/ 9（completeness theatre）
 
 ### 邊界
 
@@ -83,7 +83,7 @@ Maigo 提供十五個命令，所有命令的 source-of-truth 是 `commands/*.md
 |------|-------------|-------------|---------------|
 | Raana / Tomori | skip | run | run |
 | Soyo | 輕量 4 項 | 完整 9 項 | 完整 9 項 |
-| Taki | stop hook 兜底 | 顯式 | 顯式（並行） |
+| Taki | orchestrator 顯式執行 CLI | 顯式 | 顯式（並行） |
 
 ## `/maigo:review` — Review 既有變更
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -142,7 +142,7 @@ Rule dict 的可選欄位。偵測命中時，hook 在 user project 的 `.claude
 pattern 會命中正當內容（註解、對照表、fixture、詞彙表）或無關的共現字串，
 判準回非預期值時錯的往往是判準而不是產物，而照字面「修好它」比原狀更糟。
 
-同一組偵測邏輯（`hooks/_grep_criteria.py`）也被 TeammateIdle 的
+同一組偵測邏輯（`hooks/_grep_criteria.py`）也被 SubagentStop 的
 燈 (Tomori) 檢查重用，掃她剛寫進 `.maigo/plan-<id>.md` 的驗收條件。
 
 ### 放行為什麼不輸出 decision
@@ -217,10 +217,15 @@ python3 scripts/token_usage_summary.py              # 最近 7 天，含角色�
 python3 scripts/token_usage_summary.py --days 30    # 自訂觀察期間
 ```
 
-## TeammateIdle — `hooks/teammate_quality_check.py`
+## SubagentStop — `hooks/teammate_quality_check.py`
 
-agent 跑完輸出送回 orchestrator 時觸發。
-檢查輸出符合該角色的最低規格，不符合就 block 並要求補完。
+由 Agent 工具啟動的 Maigo subagent 回覆完成時觸發。Matcher 限定 Maigo 的五位角色，
+以 `agent_type`（例如 `maigo:Soyo`）辨識角色，從 `last_assistant_message` 取得輸出，
+並以事件提供的 `cwd` 檢查 artifact、寫入 retry log。
+
+不符合最低規格就輸出 `{"decision":"block","reason":"..."}`，exit 0；通過時省略
+`decision`。這是 [SubagentStop 的官方契約](https://code.claude.com/docs/en/hooks#subagentstop)。
+原先使用的 TeammateIdle 屬於 agent team 的閒置事件，沒有直接提供角色輸出，已移除該註冊。
 
 ### 各角色擋的條件
 
@@ -232,12 +237,14 @@ agent 跑完輸出送回 orchestrator 時觸發。
 | **Tomori** | 結構段落：`## Goal` / `## Steps` / `## Rubric` / `## Acceptance` / `## 目標` / `## 步驟` 之一 | 「缺計畫結構」 |
 | **Tomori** | `.maigo/plan(-<id>).md` 的驗收條件**不得**把字面 grep 命中數當性質證明（判準同 PreToolUse；讀不到檔案就 fail-open）| 「把字面 grep 的命中數當成抽象性質的證明」 |
 | **Soyo** | `## Loaded memory entries` 段 | 「缺 memory 載入回報」 |
-| **Soyo** | verdict 字串：`APPROVED` / `NEEDS_CHANGES` / `BLOCKED` | 「沒下 verdict」 |
-| **Soyo** | checklist 項目：`[x]` / `[X]` / `[ ]` | 「沒 checklist」 |
-| **Soyo** | 非 APPROVED 時：`must-fix` / `改法` / `evidence` / `待補` 之一 | 「擋下卻沒列 must-fix」 |
+| **🟡 Soyo** | review verdict：`APPROVED` / `NEEDS_CHANGES` / `BLOCKED`；triage：`READY` / `NEEDS_INFO` / `DUP` / `CLOSE` | 「沒下 verdict」 |
+| **🟡 Soyo** | `## Checklist` 段依序保留至少 9 項：`[x]` / `[X]` / `[ ]` / `[—]`；quick 只允許略過 2、3、6、8、9，附 `skipped by mode=quick`；triage 的非 bug 情境可略過 2–4 | 「checklist 不完整或略過必要項目」 |
+| **🟡 Soyo** | `APPROVED` / `READY` 時不可有 `[ ]` | 「尚有未通過項目」 |
+| **🟡 Soyo** | review 非 APPROVED 時：`must-fix` / `改法` / `evidence` / `待補` 之一 | 「擋下卻沒列 must-fix」 |
 | **Soyo** | 同 must-fix key 連續 ≥ 2 次 | block reason 前綴 `⚠️ RETRY LIMIT REACHED (Soyo):` |
 | **Taki** | `exit <number>` 模式 | 「沒貼 exit code」 |
 | **Taki** | `PASS` 或 `FAIL` 之一 | 「沒給最終 verdict」 |
+| **🟣 Taki** | `PASS` 時最後列出的 command exit code 必須是 0 | 「PASS 與 exit code 矛盾」 |
 | **Taki** | **不能包含** `should work` / `looks good` / `應該可以` / `看起來沒問題` 等 hedge 語 | 「verifier 只能拿 exit code 講話」 |
 | **Anon** | 至少一個 file path reference（regex 抓 `*.py` / `*.md` / `*.yml` / `*.yaml` / `*.json` / `*.toml` / `*.txt` / `*.sh` / `*.cfg`）| 「沒看到檔案路徑 reference」 |
 
@@ -261,8 +268,12 @@ backtick 內的 file path（去掉 `:line` 後綴）當 key；無 file 引用的
 
 ### Fail-open 情況
 
-- malformed input（沒 `teammate_role` 或 `teammate_output`）→ approve
-- input 不是有效 JSON → approve
+- 沒有有效 `agent_type`、非 Maigo 角色，或 input 不是有效 JSON object → 略過，不輸出 decision
+- 已辨識的 Maigo 角色缺少 `last_assistant_message`、或 `cwd` 無效 → block
+
+這是輸出格式檢查，不能證明 checklist 判斷正確或 command 真的執行過；實際測試證據由
+下節的顯式驗證 CLI 取得。Review 的 NEEDS_CHANGES／BLOCKED 格式完整時可交回 orchestrator，
+不代表變更已獲 APPROVED。
 
 ### Timeout
 
@@ -272,6 +283,37 @@ backtick 內的 file path（去掉 `:line` 後綴）當 key；無 file 引用的
 
 編輯 `hooks/teammate_quality_check.py`，在 `ROLE_HANDLERS` 字典加一個新 mapping，
 並寫對應的 `check_<role>` 函式。每個 handler 都要呼叫 `emit("block", ...)` 或 `emit("approve", ...)`。
+
+## Explicit task verification
+
+`quick` 在所有宿主都明確執行以下 CLI；不需要 lifecycle hooks、subagents 或特定模型。
+`--cwd` 必須指向本次工作目錄，即使該 repo 乾淨、工作已 commit，也會執行驗證。
+
+```bash
+python3 /path/to/maigo/scripts/verify_task.py --cwd /path/to/project
+python3 /path/to/maigo/scripts/verify_task.py --cwd /path/to/project --command 'uv run pytest tests/test_example.py'
+```
+
+CLI 與 Stop hook 共用 `run_verification()`。stdout 為單一 JSON object，包含
+`schema_version`、`cwd`、開始／結束時間、`status`、`reason`、實際執行的 `command`、
+子程序 `exit_code` 和 `output`。未執行或無法取得完成狀態時，`exit_code` 為 `null`。
+可用 shell redirect 保存本次結果；改動後必須重跑。
+
+| status | CLI exit | 意義 |
+|---|---|---|
+| `passed` | 0 | 該次驗證 command exit 0 |
+| `failed` | 1 | 測試或 collection／設定檢查失敗 |
+| `unavailable` | 2 | 無 runner／測試設定、無法啟動、逾時、或 host build env 失敗 |
+| `skipped` | 3 | `.claude/skip-test-verification` 已設定原因，沒有執行測試 |
+| `known_failures` | 4 | command 非零，能解析的失敗都在已知失敗名單中 |
+
+`--command` 優先於 `.claude/test-command`，以 argv 解析，沒有 shell expansion。
+既有 skip 設定仍生效。未指定 command 時沿用以下 Stop hook 的 runner 偵測與設定。
+CLI 的 status 不代表 review 已通過，也不涵蓋未執行的其他檢查。
+
+沒有 hook 的宿主仍靠 command 顯式呼叫，不能宣稱有機器強制的 completion gate。
+Stop hook 保留既有 skip／known-failure 放行政策；CLI 用獨立狀態和非零 exit code 表示這些例外，
+讓呼叫端依已授權的政策決定後續動作，不能把它們當成測試全綠。
 
 ## Stop — `hooks/verify_completion.py`
 
@@ -354,8 +396,8 @@ message 強調「這不是 test fail，是 import 錯」。
 要看 hook 真的有跑、回傳什麼：
 
 ```bash
-# 模擬 TeammateIdle 觸發
-python3 -c "import json,sys; print(json.dumps({'teammate_role':'Soyo','teammate_output':'## Verdict\nBLOCKED\n## Checklist\n- [ ] foo'}))" \
+# 模擬 SubagentStop 觸發
+python3 -c "import json; print(json.dumps({'hook_event_name':'SubagentStop','agent_type':'maigo:Soyo','last_assistant_message':'## Verdict\nBLOCKED\n## Checklist\n- [ ] foo'}))" \
   | python3 hooks/teammate_quality_check.py
 
 # 模擬 Stop 觸發

--- a/hooks/_hook_io.py
+++ b/hooks/_hook_io.py
@@ -1,8 +1,7 @@
 """Shared I/O helpers for Maigo hooks.
 
-All hooks emit a JSON `{decision, reason, systemMessage}` payload to stdout
-then `sys.exit(0)`. Single source of truth lives here so the payload shape
-stays identical across hooks.
+Decision encoding depends on the hook event. PreToolUse supports the legacy
+decision payload; Stop/SubagentStop omit decision when allowing completion.
 """
 
 from __future__ import annotations
@@ -15,5 +14,14 @@ from typing import NoReturn
 def emit(decision: str, reason: str) -> NoReturn:
     """Write the standard hook decision payload to stdout and exit 0."""
     payload = {"decision": decision, "reason": reason, "systemMessage": reason}
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    sys.exit(0)
+
+
+def emit_stop(decision: str, reason: str) -> NoReturn:
+    """Stop/SubagentStop: omit decision to allow; block asks the agent to continue."""
+    payload = {"reason": reason, "systemMessage": reason}
+    if decision == "block":
+        payload["decision"] = "block"
     sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
     sys.exit(0)

--- a/hooks/_retry_log.py
+++ b/hooks/_retry_log.py
@@ -38,7 +38,8 @@ def record_and_count(log_path: Path, keys: set[str], entry_key: str) -> dict[str
                         counts[k] = counts.get(k, 0) + 1
                 except json.JSONDecodeError:
                     pass  # corrupted line — skip, don't crash
-        ts = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # verify_task.py also calls this from a standalone system Python.
+        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")  # noqa: UP017
         new_entry = json.dumps({"ts": ts, entry_key: sorted(keys)}, ensure_ascii=False)
         with log_path.open("a", encoding="utf-8") as f:
             f.write(new_entry + "\n")

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -46,8 +46,9 @@
         ]
       }
     ],
-    "TeammateIdle": [
+    "SubagentStop": [
       {
+        "matcher": "^(maigo:)?(Raana|Tomori|Anon|Soyo|Taki)$",
         "hooks": [
           {
             "type": "command",

--- a/hooks/teammate_quality_check.py
+++ b/hooks/teammate_quality_check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Maigo TeammateIdle hook：各 agent 輸出規格檢查。
+"""Maigo SubagentStop hook：各 agent 輸出規格檢查。
 
 失敗時 block（要 agent 補完輸出）；輸入異常 / 角色未定義時 fail-open。
 """
@@ -14,7 +14,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _grep_criteria import block_reason, find_literal_grep_criteria
-from _hook_io import emit
+from _hook_io import emit_stop as emit
 from _retry_log import record_and_count
 
 SOYO_RETRY_LIMIT = 2
@@ -172,22 +172,47 @@ def check_tomori(out: str) -> None:
 
 def check_soyo(out: str) -> None:
     require_memory_header(out, "爽世 (Soyo)")
-    verdict_match = re.search(r"\b(APPROVED|NEEDS_CHANGES|BLOCKED)\b", out)
+    verdict_match = re.search(
+        r"\b(APPROVED|NEEDS_CHANGES|BLOCKED|READY|NEEDS_INFO|DUP|CLOSE)\b", out
+    )
     if not verdict_match:
         emit(
             "block",
-            "爽世 (Soyo) 的輸出沒看到 verdict（APPROVED / NEEDS_CHANGES / BLOCKED）。預設 BLOCKED，所有 review 都要明確寫出 verdict。",
+            "爽世 (Soyo) 的輸出沒看到 review verdict（APPROVED / NEEDS_CHANGES / BLOCKED）或 triage verdict（READY / NEEDS_INFO / DUP / CLOSE）。",
         )
         return
     verdict = verdict_match.group(1)
 
-    if not re.search(r"\[[xX ]\]", out):
+    checklist = re.search(
+        r"^##\s+Checklist\b[^\n]*\n(.*?)(?=^##\s|\Z)",
+        out,
+        re.MULTILINE | re.DOTALL | re.IGNORECASE,
+    )
+    if checklist is None:
+        emit("block", "爽世 (Soyo) 的輸出缺少 ## Checklist 段。")
+        return
+    rows = re.findall(r"^.*\[([xX —-])\].*$", checklist.group(1), re.MULTILINE)
+    if len(rows) < 9:
         emit(
             "block",
-            "爽世 (Soyo) 的輸出缺少 checklist（[x] / [ ] 項目）。9 項強制檢查必須逐項標示。",
+            "爽世 (Soyo) 的 ## Checklist 必須依序列出至少 9 項（[x] / [ ] / [—]）；quick 的略過項也要列出原因。",
         )
 
-    if verdict != "APPROVED":
+    triage = verdict in {"READY", "NEEDS_INFO", "DUP", "CLOSE"}
+    skipped = {index for index, mark in enumerate(rows, 1) if mark in {"—", "-"}}
+    allowed_skips = {2, 3, 4} if triage else {2, 3, 6, 8, 9}
+    if skipped and (
+        not skipped <= allowed_skips
+        or (not triage and "skipped by mode=quick" not in checklist.group(1))
+    ):
+        emit(
+            "block",
+            "爽世 (Soyo) 的 checklist 略過了必要項目，或缺少 skipped by mode=quick 原因。",
+        )
+    if verdict in {"APPROVED", "READY"} and " " in rows:
+        emit("block", f"爽世 (Soyo) 的 checklist 仍有 [ ]，不能給 {verdict}。")
+
+    if not triage and verdict != "APPROVED":
         if not re.search(r"(must[-\s]?fix|改法|evidence|待補)", out, re.IGNORECASE):
             emit(
                 "block",
@@ -344,7 +369,8 @@ def check_anon(out: str) -> None:
 
 
 def check_taki(out: str) -> None:
-    if not re.search(r"exit\s+[0-9]+", out):
+    exit_codes = re.findall(r"exit\s+(-?[0-9]+)", out)
+    if not exit_codes:
         emit(
             "block",
             "立希 (Taki) 沒看到 exit code。要拿真的 command 跑過，不是憑感覺說 PASS / FAIL。",
@@ -355,6 +381,11 @@ def check_taki(out: str) -> None:
         emit("block", "立希 (Taki) 沒給最終 verdict（PASS / FAIL）。")
         return
     verdict = verdict_match.group(1)
+    if verdict == "PASS" and int(exit_codes[-1]) != 0:
+        emit(
+            "block",
+            "立希 (Taki) 宣告 PASS，但最後列出的 command exit code 非 0。請分開列出失敗與修正後的驗證結果。",
+        )
 
     hedge_patterns = [
         r"should\s+work",
@@ -400,18 +431,37 @@ def main() -> None:
     except json.JSONDecodeError:
         emit("approve", "輸入不是有效 JSON，Maigo teammate check 跳過")
 
-    role = (data.get("teammate_role") or "").strip()
-    output = data.get("teammate_output") or ""
-
-    if not role or not output:
-        emit("approve", "輸入缺少 teammate_role 或 teammate_output，跳過")
+    if not isinstance(data, dict):
+        emit("approve", "輸入不是 JSON object，Maigo subagent check 跳過")
+        return
+    role = data.get("agent_type")
+    if not isinstance(role, str) or not role.strip():
+        emit("approve", "輸入缺少 agent_type，無法辨識 Maigo subagent，跳過")
+        return
+    role = role.strip().removeprefix("maigo:")
 
     handler = ROLE_HANDLERS.get(role)
     if handler is None:
         emit("approve", f"{role}：未設規格，預設通過")
         return
 
-    handler(output)
+    output = data.get("last_assistant_message")
+    if not isinstance(output, str) or not output.strip():
+        emit(
+            "block",
+            f"{role} 的 SubagentStop 缺少 last_assistant_message，請補完角色輸出。",
+        )
+        return
+    cwd = data.get("cwd") or os.getcwd()
+    if not isinstance(cwd, str) or not Path(cwd).is_dir():
+        emit("block", "SubagentStop 的 cwd 不是有效目錄，無法檢查角色產物。")
+        return
+    previous_cwd = os.getcwd()
+    try:
+        os.chdir(cwd)
+        handler(output)
+    finally:
+        os.chdir(previous_cwd)
 
 
 if __name__ == "__main__":

--- a/hooks/verify_completion.py
+++ b/hooks/verify_completion.py
@@ -22,11 +22,12 @@ import shlex
 import shutil
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import NoReturn
+from typing import Literal, NoReturn
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _hook_io import emit  # noqa: E402
+from _hook_io import emit_stop as emit  # noqa: E402
 from _retry_log import record_and_count  # noqa: E402
 from _session_head import head_moved  # noqa: E402
 from _token_usage import LOG_PATH, format_one_line, summarize  # noqa: E402
@@ -172,6 +173,8 @@ def run_command(cmd: list[str], cwd: Path) -> tuple[int, str]:
         return -1, f"command not found: {cmd[0]}"
     except subprocess.TimeoutExpired:
         return -1, f"timeout after {TEST_TIMEOUT_SEC}s: {' '.join(cmd)}"
+    except OSError as exc:
+        return -1, f"cannot run {' '.join(cmd)}: {exc}"
 
 
 def extract_failures(output: str) -> set[str]:
@@ -235,57 +238,77 @@ def approve_with_usage(reason: str, cwd: Path, session_id: object) -> NoReturn:
     raise AssertionError("emit() must exit")
 
 
-def main() -> None:
-    raw = sys.stdin.read()
-    try:
-        data = json.loads(raw) if raw.strip() else {}
-    except json.JSONDecodeError:
-        data = {}
+VerificationStatus = Literal[
+    "passed", "failed", "unavailable", "skipped", "known_failures"
+]
 
-    cwd = Path(data.get("cwd") or os.getcwd()).resolve()
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Actual command evidence shared by the hook and explicit task verification."""
+
+    status: VerificationStatus
+    reason: str
+    command: list[str] | None = None
+    exit_code: int | None = None
+    output: str = ""
+
+
+def run_verification(cwd: Path, command: str | None = None) -> VerificationResult:
+    """Always verify when explicitly invoked, including clean/committed worktrees.
+
+    The hook alone decides whether a read-only session needs verification.
+    An unavailable runner, configured skip, or known failure is never PASS.
+    """
     claude_dir = cwd / ".claude"
-    session_id = data.get("session_id")
-
-    if not has_git_modifications(cwd) and not head_moved(cwd, session_id):
-        approve_with_usage(
-            "立希 (Taki)：本次 session 無檔案修改（working tree 乾淨且 HEAD 未變動），跳過 test 驗證",
-            cwd,
-            session_id,
-        )
-
     skip_reason = read_config_line(claude_dir / "skip-test-verification")
     if skip_reason is not None:
-        approve_with_usage(f"verify_completion 跳過：{skip_reason}", cwd, session_id)
+        return VerificationResult("skipped", f"verify_completion 跳過：{skip_reason}")
 
-    custom_cmd = read_config_line(claude_dir / "test-command")
-    cmd = shlex.split(custom_cmd) if custom_cmd else detect_test_command(cwd)
+    custom_cmd = (
+        command
+        if command is not None
+        else read_config_line(claude_dir / "test-command")
+    )
+    try:
+        cmd = (
+            shlex.split(custom_cmd)
+            if custom_cmd is not None
+            else detect_test_command(cwd)
+        )
+    except ValueError as exc:
+        return VerificationResult("unavailable", f"無法解析 test command：{exc}")
 
     if not custom_cmd and (cwd / "uv.lock").is_file() and shutil.which("uv") is None:
-        approve_with_usage(
+        return VerificationResult(
+            "unavailable",
             "立希 (Taki)：偵測到 uv.lock 但 uv 不在 PATH，已跳過 test 驗證——裝 uv 或在 .claude/test-command 指定可跑的指令。",
-            cwd,
-            session_id,
         )
-        return
 
-    if cmd is None:
-        approve_with_usage(
-            "立希 (Taki)：偵測不到 test 設定，跳過（no-op）", cwd, session_id
+    if not cmd:
+        return VerificationResult(
+            "unavailable", "立希 (Taki)：偵測不到可執行的 test 設定，未驗證"
         )
-        return
 
     known = read_known_failures(claude_dir / "known-test-failures")
     exit_code, output = run_command(cmd, cwd)
 
+    def result(status: VerificationStatus, reason: str) -> VerificationResult:
+        return VerificationResult(
+            status, reason, cmd, None if exit_code == -1 else exit_code, output
+        )
+
     if exit_code == 0:
-        approve_with_usage(f"立希 (Taki)：`{' '.join(cmd)}` 通過", cwd, session_id)
+        return result("passed", f"立希 (Taki)：`{' '.join(cmd)}` 通過")
+
+    if exit_code == -1:
+        return result("unavailable", f"立希 (Taki)：無法完成驗證：{output}")
 
     build_env_match = BUILD_ENV_ERROR_RE.search(output)
     if build_env_match:
-        approve_with_usage(
+        return result(
+            "unavailable",
             f"立希 (Taki)：`{' '.join(cmd)}` 失敗於 host build env（{build_env_match.group(0)!r}），不是 test 失敗。跳過——修 host build env，或在 `.claude/test-command` 改成可跑的指令，或 `.claude/skip-test-verification` 寫一行 reason 永久關閉本 worktree 的檢查。",
-            cwd,
-            session_id,
         )
 
     fatal_match = FATAL_MARKER_RE.search(output)
@@ -293,8 +316,8 @@ def main() -> None:
         fatal_key = f"__fatal__:{fatal_match.group(1)}:{' '.join(cmd)}"
         counts = _record_and_count(_retry_log_path(cwd), {fatal_key})
         warning = _retry_warning(counts, {fatal_key}, "import / collection 錯")
-        emit(
-            "block",
+        return result(
+            "failed",
             f"{warning}立希 (Taki)：`{' '.join(cmd)}` 出現 {fatal_match.group(1)}（import / collection 錯，不是 test 失敗）。先修這個。",
         )
 
@@ -320,18 +343,17 @@ def main() -> None:
                 f"——同 test ID 連紅 {RETRY_LIMIT} 次即達 limit。\n\n"
             )
         details = "\n".join(f"  - {f}" for f in sorted(new_failures))
-        emit(
-            "block",
+        return result(
+            "failed",
             f"{warning}立希 (Taki)：`{' '.join(cmd)}` exit {exit_code}，"
             f"{len(new_failures)} 個新失敗：\n{details}\n\n"
             f"（已知失敗已忽略；要忽略新失敗，加到 .claude/known-test-failures）",
         )
 
     if actual and not new_failures:
-        approve_with_usage(
-            f"立希 (Taki)：{len(actual)} 個失敗全在 known-test-failures 名單，放行",
-            cwd,
-            session_id,
+        return result(
+            "known_failures",
+            f"立希 (Taki)：{len(actual)} 個失敗全在 known-test-failures 名單，仍有已知失敗",
         )
 
     # No parseable failures at this point. If the output looks like a
@@ -347,8 +369,8 @@ def main() -> None:
         collection_key = f"__collection__:{collection_match.group(0)}:{' '.join(cmd)}"
         counts = _record_and_count(_retry_log_path(cwd), {collection_key})
         warning = _retry_warning(counts, {collection_key}, "test collection / 設定錯")
-        emit(
-            "block",
+        return result(
+            "failed",
             f"{warning}立希 (Taki)：`{' '.join(cmd)}` 失敗於 test collection / 設定（{collection_match.group(0)!r}），suite 根本沒跑。常見於 uv-workspace monorepo 根目錄要用 `--project`。在 `.claude/test-command` 改成可跑的指令（例如 `uv run --project <pkg> pytest <path>`），或 `.claude/skip-test-verification` 寫一行 reason 明確關閉本 worktree 的檢查。",
         )
 
@@ -361,14 +383,44 @@ def main() -> None:
     unparsed_key = f"__unparsed_nonzero__:{' '.join(cmd)}"
     counts = _record_and_count(_retry_log_path(cwd), {unparsed_key})
     if counts.get(unparsed_key, 0) >= RETRY_LIMIT:
-        emit(
-            "block",
+        return result(
+            "failed",
             f"⚠️ RETRY LIMIT REACHED: 立希 (Taki)：`{' '.join(cmd)}` exit {exit_code} 已連續 ≥ {RETRY_LIMIT} 次無法 parse failure（本次含）。停止重試以免無限迴圈，請人工介入確認。依 skills/failure-handling 的「無限迴圈防護」。若這是 collection / 設定問題，在 `.claude/test-command` 改成可跑的指令，或 `.claude/skip-test-verification` 寫一行 reason 明確關閉本 worktree 的檢查。Raw tail:\n{tail}",
         )
-    emit(
-        "block",
+    return result(
+        "failed",
         f"立希 (Taki)：`{' '.join(cmd)}` exit {exit_code}，無法 parse failure 名稱。Raw tail:\n{tail}",
     )
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+
+    cwd = Path(data.get("cwd") or os.getcwd()).resolve()
+    session_id = data.get("session_id")
+    if not has_git_modifications(cwd) and not head_moved(cwd, session_id):
+        approve_with_usage(
+            "立希 (Taki)：本次 session 無檔案修改（working tree 乾淨且 HEAD 未變動），跳過 test 驗證",
+            cwd,
+            session_id,
+        )
+
+    result = run_verification(cwd)
+    if result.status == "failed" or (
+        result.status == "unavailable"
+        and result.command is not None
+        and result.exit_code is None
+    ):
+        emit("block", result.reason)
+    # Preserve the optional Stop hook's existing skip/known-failure policy.
+    # Explicit verification exposes these states separately and exits nonzero.
+    approve_with_usage(result.reason, cwd, session_id)
 
 
 if __name__ == "__main__":

--- a/scripts/validate_plugin.py
+++ b/scripts/validate_plugin.py
@@ -113,6 +113,7 @@ def check_hooks_schema() -> CheckResult:
         "PreToolUse",
         "PostToolUse",
         "TeammateIdle",
+        "SubagentStop",
         "Stop",
     }
     for event, configs in hooks.items():

--- a/scripts/verify_task.py
+++ b/scripts/verify_task.py
@@ -1,0 +1,60 @@
+"""Run task verification without relying on any host's lifecycle hooks.
+
+Usage: python3 /path/to/maigo/scripts/verify_task.py --cwd /path/to/project
+An optional --command overrides test discovery; it is an argv string, not a shell.
+stdout is a JSON evidence record. Only status=passed exits zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from hooks.verify_completion import VerificationResult, run_verification  # noqa: E402
+
+EXIT_CODES = {
+    "passed": 0,
+    "failed": 1,
+    "unavailable": 2,
+    "skipped": 3,
+    "known_failures": 4,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cwd", type=Path, required=True)
+    parser.add_argument(
+        "--command", help="Explicit test argv, parsed with shlex (no shell)"
+    )
+    args = parser.parse_args()
+    cwd = args.cwd.resolve()
+    # Standalone entry points may run under macOS's system Python 3.9.
+    started_at = datetime.now(timezone.utc).isoformat()  # noqa: UP017
+    result = (
+        run_verification(cwd, args.command)
+        if cwd.is_dir()
+        else VerificationResult("unavailable", f"cwd is not a directory: {cwd}")
+    )
+    print(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "cwd": str(cwd),
+                "started_at": started_at,
+                "finished_at": datetime.now(timezone.utc).isoformat(),  # noqa: UP017
+                **asdict(result),
+            },
+            ensure_ascii=False,
+        )
+    )
+    sys.exit(EXIT_CODES[result.status])
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/command-router/SKILL.md
+++ b/skills/command-router/SKILL.md
@@ -73,7 +73,7 @@ Translate Claude Code concepts without changing the workflow's intent:
 - Map explicit agent or `Task` delegation to Codex sub-agents when collaboration tools are available. If unavailable, execute the named roles sequentially in the main agent and disclose the fallback.
 - Use Codex planning tools for command-level plans when available, while preserving `.maigo/*.md` artifacts required by the command.
 - Use patch-based file editing and the current shell/tooling policies rather than Claude-specific Read, Write, Edit, or Bash tool names.
-- Claude Code lifecycle hooks are not installed by the Codex manifest. Run the command's required review and verification steps explicitly; never claim that TeammateIdle or Stop hooks enforced completion.
+- Claude Code lifecycle hooks are not installed by the Codex manifest. Run the command's required review and verification steps explicitly; never claim that SubagentStop or Stop hooks enforced completion. For `quick`, run `<plugin-root>/scripts/verify_task.py --cwd <project-cwd>` and follow its status contract in `commands/quick.md`; hook exit 0 is not a test result.
 - If a command needs to write outside the active workspace, request the required approval instead of silently skipping the write.
 
 ## Poor command UX

--- a/skills/pr-sync-check/SKILL.md
+++ b/skills/pr-sync-check/SKILL.md
@@ -18,7 +18,7 @@ description: This skill should be used after a change is complete — at the wra
 
 改動完成、收尾階段，且當前 branch **可能**已經對應一個開啟中的 PR 時。三個既有收尾點套用：
 
-- `/maigo:quick` 步驟 4（Stop hook 綠、commit message 草擬前後皆可）
+- `/maigo:quick` 步驟 4（顯式驗證 passed、commit message 草擬前後皆可）
 - `/maigo:go` / `/maigo:team`（經 [`skills/teammate-flow`](https://github.com/Lee-W/maigo/blob/main/skills/teammate-flow/SKILL.md)「Commit message draft」段，Taki 全綠後）
 - `/maigo:address-comments` 步驟 6 Finale（這裡已知 PR 存在——步驟 1 的 pre-flight gate 已經核過，可以省略步驟 1）
 

--- a/tests/test_teammate_quality_check.py
+++ b/tests/test_teammate_quality_check.py
@@ -4,11 +4,36 @@ from __future__ import annotations
 
 import io
 import json
+import re
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
 import hooks.teammate_quality_check as tqc
 from tests.conftest import run_hook_main
+
+
+CHECKLIST = (
+    "## Checklist\n"
+    + "\n".join(
+        f"- [x] {item}"
+        for item in (
+            "acceptance match",
+            "evidence per function",
+            "edge case coverage",
+            "convention conformance",
+            "no unsafe pattern",
+            "no unexplained magic",
+            "no TODO evasion",
+            "no defensive bloat",
+            "no completeness theatre",
+        )
+    )
+    + "\n"
+)
+MEMORY = "## Loaded memory entries\n（無相關 entry）\n"
 
 
 @pytest.fixture(autouse=True)
@@ -31,7 +56,7 @@ class TestCheckRaana:
         with pytest.raises(SystemExit):
             tqc.check_raana("## Loaded memory entries\n（無相關 entry）\n")
         result = json.loads(capsys.readouterr().out.strip())
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_missing_memory_header_blocks(self, capsys: pytest.CaptureFixture):
         with pytest.raises(SystemExit):
@@ -66,7 +91,7 @@ class TestCheckTomori:
                 ".maigo/plan.md\n## Goal\n## Steps\n"
             )
         result = json.loads(capsys.readouterr().out.strip())
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_chinese_headings_approves(self, capsys: pytest.CaptureFixture):
         with pytest.raises(SystemExit):
@@ -75,7 +100,7 @@ class TestCheckTomori:
                 ".maigo/plan.md\n## 目標\n## 步驟\n"
             )
         result = json.loads(capsys.readouterr().out.strip())
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_missing_memory_header_blocks(self, capsys: pytest.CaptureFixture):
         with pytest.raises(SystemExit):
@@ -93,7 +118,7 @@ class TestCheckTomori:
                 "## Suggested PR description\n## Summary\n...\n"
             )
         result = json.loads(capsys.readouterr().out.strip())
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
         assert "PR 草稿" in result["reason"]
 
     def test_pr_draft_missing_description_blocks(self, capsys: pytest.CaptureFixture):
@@ -124,7 +149,7 @@ class TestCheckTomori:
                 "## Category\nbug\n"
             )
         result = json.loads(capsys.readouterr().out.strip())
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_triage_path_but_no_category_heading_blocks(
         self, capsys: pytest.CaptureFixture
@@ -147,7 +172,7 @@ class TestCheckTomori:
                 ".maigo/review-rubric-71380.md\n## Rubric\n"
             )
         result = json.loads(capsys.readouterr().out.strip())
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
 
 # ---------------------------------------------------------------------------
@@ -187,7 +212,7 @@ class TestTomoriPlanCriteria:
         with pytest.raises(SystemExit):
             tqc.check_tomori(self.OUT)
         result = json.loads(capsys.readouterr().out.strip())
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_missing_plan_file_fails_open(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
@@ -196,7 +221,7 @@ class TestTomoriPlanCriteria:
         with pytest.raises(SystemExit):
             tqc.check_tomori(self.OUT)
         result = json.loads(capsys.readouterr().out.strip())
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
 
 # ---------------------------------------------------------------------------
@@ -258,19 +283,18 @@ class TestCheckSoyo:
 
     def test_approved_with_checklist_approves(self, capsys):
         result = self._run(
-            "## Loaded memory entries\n（無相關 entry）\n"
-            "APPROVED\n[x] all good\n[x] verified\n",
+            "## Loaded memory entries\n（無相關 entry）\nAPPROVED\n" + CHECKLIST,
             capsys,
         )
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_blocked_with_checklist_and_must_fix_approves(self, capsys):
         result = self._run(
             "## Loaded memory entries\n（無相關 entry）\n"
-            "BLOCKED\n[x] done\n[ ] pending\nmust-fix: broken import\n",
+            "BLOCKED\n" + CHECKLIST + "must-fix: broken import\n",
             capsys,
         )
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_missing_memory_header_blocks(self, capsys):
         result = self._run("APPROVED\n[x] all good\n[x] verified\n", capsys)
@@ -293,8 +317,7 @@ class TestSoyoRetryCount:
 
     _BLOCKED_OUTPUT = (
         "## Loaded memory entries\n（無相關 entry）\n"
-        "BLOCKED\n[x] done\n[ ] pending\n"
-        "## Must-fix\n- `hooks/foo.py:10` — broken import\n"
+        "BLOCKED\n" + CHECKLIST + "## Must-fix\n- `hooks/foo.py:10` — broken import\n"
     )
 
     def test_extract_must_fix_keys_with_file_ref(self):
@@ -329,7 +352,7 @@ class TestSoyoRetryCount:
         with pytest.raises(SystemExit):
             tqc.check_soyo(self._BLOCKED_OUTPUT)
         result = json.loads(capsys.readouterr().out.strip())
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
         # log file should exist with 1 line
         log_file = tmp_path / "soyo-must-fix.jsonl"
         assert log_file.is_file()
@@ -373,13 +396,12 @@ class TestSoyoRetryCount:
         monkeypatch.setattr(tqc, "_RETRY_LOG_BASE", tmp_path)
         monkeypatch.chdir(tmp_path)
         approved_output = (
-            "## Loaded memory entries\n（無相關 entry）\n"
-            "APPROVED\n[x] all good\n[x] verified\n"
+            "## Loaded memory entries\n（無相關 entry）\nAPPROVED\n" + CHECKLIST
         )
         with pytest.raises(SystemExit):
             tqc.check_soyo(approved_output)
         result = json.loads(capsys.readouterr().out.strip())
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
         # No log file should be written
         log_file = tmp_path / "soyo-must-fix.jsonl"
         assert not log_file.exists()
@@ -429,7 +451,12 @@ class TestCheckTaki:
 
     def test_clean_pass_approves(self, capsys):
         result = self._run("exit 0\nPASS\nAll tests passed.", capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
+
+    @pytest.mark.parametrize("exit_code", [1, -1, 137])
+    def test_pass_with_nonzero_exit_blocks(self, exit_code, capsys):
+        result = self._run(f"PASS\nexit {exit_code}", capsys)
+        assert result["decision"] == "block"
 
 
 # ---------------------------------------------------------------------------
@@ -450,21 +477,21 @@ class TestCheckAnon:
 
     def test_with_py_path_approves(self, capsys):
         result = self._run("我動了 hooks/foo.py\n", capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_with_md_path_approves(self, capsys):
         result = self._run("更新了 docs/reference/hooks.md\n", capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_hedge_language_does_not_block(self, capsys):
         result = self._run(
             "可能要先確認 X 是否需要再動。我改了 commands/retro.md\n", capsys
         )
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_no_memory_header_does_not_block(self, capsys):
         result = self._run("我改了 hooks/check.py\n", capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_url_with_md_does_not_approve(self, capsys):
         result = self._run(
@@ -479,20 +506,93 @@ class TestCheckAnon:
 
 
 class TestMain:
+    @pytest.mark.parametrize(
+        ("role", "output", "blocked"),
+        [
+            ("maigo:Soyo", MEMORY + "APPROVED\n" + CHECKLIST, False),
+            ("maigo:Soyo", MEMORY + "APPROVED\n## Checklist\n- [x] done", True),
+            (
+                "maigo:Soyo",
+                MEMORY + "APPROVED\n" + CHECKLIST.replace("[x]", "[ ]", 1),
+                True,
+            ),
+            ("maigo:Soyo", MEMORY + "READY\n" + CHECKLIST, False),
+            ("maigo:Taki", "PASS\nexit 1", True),
+            ("maigo:Taki", "PASS\nexit 0", False),
+            ("maigo:Anon", "Updated src/example.py", False),
+            ("maigo:Anon", "", True),
+            ("other-plugin:Soyo", "", False),
+        ],
+    )
+    def test_documented_subagent_stop_contract(self, role, output, blocked, tmp_path):
+        root = Path(__file__).resolve().parents[1]
+        payload = {
+            "hook_event_name": "SubagentStop",
+            "session_id": "test-session",
+            "agent_id": "test-agent",
+            "agent_type": role,
+            "cwd": str(tmp_path),
+            "stop_hook_active": False,
+            "transcript_path": str(tmp_path / "parent.jsonl"),
+            "agent_transcript_path": str(tmp_path / "agent.jsonl"),
+            "last_assistant_message": output,
+        }
+        proc = subprocess.run(
+            [sys.executable, str(root / "hooks/teammate_quality_check.py")],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+        )
+        assert proc.returncode == 0
+        assert not proc.stderr
+        result = json.loads(proc.stdout)
+        assert result.get("decision") == ("block" if blocked else None)
+
+    def test_registered_event_matches_maigo_only(self):
+        root = Path(__file__).resolve().parents[1]
+        hooks = json.loads((root / "hooks/hooks.json").read_text())["hooks"]
+        assert "TeammateIdle" not in hooks
+        matcher = hooks["SubagentStop"][0]["matcher"]
+        for agent in (root / "agents").glob("*.md"):
+            assert re.fullmatch(matcher, f"maigo:{agent.stem}")
+        assert not re.fullmatch(matcher, "other-plugin:Soyo")
+
+    def test_quick_skips_only_optional_items(self, monkeypatch, capsys):
+        rows = CHECKLIST.splitlines()
+        for index in (2, 3, 6, 8, 9):
+            rows[index] = rows[index].replace("[x]", "[—]") + " — skipped by mode=quick"
+        output = MEMORY + "APPROVED\n" + "\n".join(rows)
+        result = run_hook_main(
+            tqc,
+            {"agent_type": "maigo:Soyo", "last_assistant_message": output},
+            monkeypatch,
+            capsys,
+        )
+        assert result.get("decision") is None
+        output = output.replace("[x] acceptance match", "[—] acceptance match")
+        result = run_hook_main(
+            tqc,
+            {"agent_type": "maigo:Soyo", "last_assistant_message": output},
+            monkeypatch,
+            capsys,
+        )
+        assert result["decision"] == "block"
+
     def test_tomori_role_dispatches(
         self,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture,
     ):
         payload = {
-            "teammate_role": "Tomori",
-            "teammate_output": (
+            "agent_type": "Tomori",
+            "last_assistant_message": (
                 "## Loaded memory entries\n（無相關 entry）\n"
                 ".maigo/plan.md\n## Goal\n## Steps\n"
             ),
         }
         result = run_hook_main(tqc, payload, monkeypatch, capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_planner_alias_dispatches_to_tomori(
         self,
@@ -500,14 +600,14 @@ class TestMain:
         capsys: pytest.CaptureFixture,
     ):
         payload = {
-            "teammate_role": "planner",
-            "teammate_output": (
+            "agent_type": "planner",
+            "last_assistant_message": (
                 "## Loaded memory entries\n（無相關 entry）\n"
                 ".maigo/plan.md\n## Goal\n## Steps\n"
             ),
         }
         result = run_hook_main(tqc, payload, monkeypatch, capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_unknown_role_fail_open_approves(
         self,
@@ -515,11 +615,11 @@ class TestMain:
         capsys: pytest.CaptureFixture,
     ):
         payload = {
-            "teammate_role": "SomeUnknownRole",
-            "teammate_output": "whatever",
+            "agent_type": "SomeUnknownRole",
+            "last_assistant_message": "whatever",
         }
         result = run_hook_main(tqc, payload, monkeypatch, capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_invalid_json_fail_open_approves(
         self,
@@ -530,7 +630,7 @@ class TestMain:
         with pytest.raises(SystemExit):
             tqc.main()
         result = json.loads(capsys.readouterr().out.strip())
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
     def test_anon_role_dispatches(
         self,
@@ -538,8 +638,8 @@ class TestMain:
         capsys: pytest.CaptureFixture,
     ):
         payload = {
-            "teammate_role": "Anon",
-            "teammate_output": "我改了 hooks/teammate_quality_check.py",
+            "agent_type": "Anon",
+            "last_assistant_message": "我改了 hooks/teammate_quality_check.py",
         }
         result = run_hook_main(tqc, payload, monkeypatch, capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None

--- a/tests/test_verify_completion.py
+++ b/tests/test_verify_completion.py
@@ -238,6 +238,26 @@ class TestHasGitModifications:
 
 
 class TestMain:
+    def test_unavailable_command_still_blocks_stop(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(
+            verify_completion, "has_git_modifications", lambda cwd: True
+        )
+        monkeypatch.setattr(
+            verify_completion,
+            "run_verification",
+            lambda cwd: verify_completion.VerificationResult(
+                "unavailable",
+                "runner timed out",
+                ["pytest"],
+                None,
+                "timeout",
+            ),
+        )
+        result = run_hook_main(
+            verify_completion, {"cwd": str(tmp_path)}, monkeypatch, capsys
+        )
+        assert result["decision"] == "block"
+
     def test_skip_test_verification(
         self,
         tmp_path: Path,
@@ -251,7 +271,7 @@ class TestMain:
         )
         payload = {"cwd": str(tmp_path)}
         result = run_hook_main(verify_completion, payload, monkeypatch, capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
         assert "跳過" in result["reason"]
 
     def test_no_test_command_detected(
@@ -263,7 +283,7 @@ class TestMain:
         # empty tmp_path — detect_test_command returns None
         payload = {"cwd": str(tmp_path)}
         result = run_hook_main(verify_completion, payload, monkeypatch, capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
         assert "偵測不到" in result["reason"]
 
     def test_approve_includes_session_usage(
@@ -295,7 +315,7 @@ class TestMain:
             capsys,
         )
 
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
         assert "Token usage：input 1.2k" in result["reason"]
         assert "已追蹤 1 agents" in result["reason"]
 
@@ -314,7 +334,7 @@ class TestMain:
         result = run_hook_main(
             verify_completion, {"cwd": str(tmp_path)}, monkeypatch, capsys
         )
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
         assert "無檔案修改" in result["reason"]
 
     def test_clean_tree_but_moved_head_still_verifies(
@@ -335,7 +355,7 @@ class TestMain:
         result = run_hook_main(
             verify_completion, {"cwd": str(tmp_path)}, monkeypatch, capsys
         )
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
         assert "無檔案修改" not in result["reason"]
         assert "uv 不在 PATH" in result["reason"]
 
@@ -355,7 +375,7 @@ class TestMain:
         monkeypatch.setattr(verify_completion.shutil, "which", lambda cmd: None)
         payload = {"cwd": str(tmp_path)}
         result = run_hook_main(verify_completion, payload, monkeypatch, capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
         assert "uv 不在 PATH" in result["reason"]
 
     def test_run_command_succeeds(
@@ -368,7 +388,7 @@ class TestMain:
         monkeypatch.setattr(verify_completion, "run_command", lambda cmd, cwd: (0, ""))
         payload = {"cwd": str(tmp_path)}
         result = run_hook_main(verify_completion, payload, monkeypatch, capsys)
-        assert result["decision"] == "approve"
+        assert result.get("decision") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_verify_task.py
+++ b/tests/test_verify_task.py
@@ -1,0 +1,140 @@
+"""Exercise the explicit verification entry point with real child processes."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/verify_task.py"
+
+
+def verify(cwd: Path, command: str | None = None) -> tuple[int, dict]:
+    argv = [sys.executable, str(SCRIPT), "--cwd", str(cwd)]
+    if command is not None:
+        argv.extend(["--command", command])
+    proc = subprocess.run(argv, cwd=cwd.parent, capture_output=True, text=True)
+    assert not proc.stderr, proc.stderr
+    return proc.returncode, json.loads(proc.stdout)
+
+
+@pytest.mark.parametrize("code", [0, 1, 7])
+def test_records_actual_command_result(tmp_path, code):
+    command = shlex.join(
+        [sys.executable, "-c", f"print('evidence'); raise SystemExit({code})"]
+    )
+    rc, result = verify(tmp_path, command)
+    assert rc == (0 if code == 0 else 1)
+    assert result["status"] == ("passed" if code == 0 else "failed")
+    assert result["exit_code"] == code
+    assert result["output"] == "evidence\n"
+    assert result["cwd"] == str(tmp_path.resolve())
+    assert result["command"] == shlex.split(command)
+    assert result["schema_version"] == 1
+    assert result["finished_at"] >= result["started_at"]
+
+
+def test_runs_in_clean_repository_without_session_hook(tmp_path):
+    subprocess.run(["git", "init", "--quiet"], cwd=tmp_path, check=True)
+    rc, result = verify(tmp_path, shlex.join([sys.executable, "-c", "print('ran')"]))
+    assert rc == 0
+    assert result["output"] == "ran\n"
+
+
+@pytest.mark.parametrize(
+    "command", [None, "", "'unclosed", "missing-maigo-test-runner"]
+)
+def test_unavailable_is_not_success(tmp_path, command):
+    rc, result = verify(tmp_path, command)
+    assert rc == 2
+    assert result["status"] == "unavailable"
+
+
+def test_explicit_skip_is_distinct(tmp_path):
+    config = tmp_path / ".claude"
+    config.mkdir()
+    (config / "skip-test-verification").write_text("manual hardware check required\n")
+    rc, result = verify(tmp_path)
+    assert rc == 3
+    assert result["status"] == "skipped"
+    assert result["exit_code"] is None
+    assert "manual hardware" in result["reason"]
+
+
+def test_missing_cwd_returns_structured_unavailable(tmp_path):
+    rc, result = verify(tmp_path / "missing")
+    assert rc == 2
+    assert result["status"] == "unavailable"
+    assert result["exit_code"] is None
+    assert "not a directory" in result["reason"]
+
+
+def test_known_failures_are_not_pass(tmp_path):
+    config = tmp_path / ".claude"
+    config.mkdir()
+    (config / "known-test-failures").write_text("tests/example.py::test_old\n")
+    rc, result = verify(
+        tmp_path,
+        shlex.join(
+            [
+                sys.executable,
+                "-c",
+                "print('FAILED tests/example.py::test_old'); raise SystemExit(1)",
+            ]
+        ),
+    )
+    assert rc == 4
+    assert result["status"] == "known_failures"
+    assert result["exit_code"] == 1
+
+
+def test_build_environment_failure_is_unavailable(tmp_path):
+    rc, result = verify(
+        tmp_path,
+        shlex.join(
+            [
+                sys.executable,
+                "-c",
+                "print('CMake configuration failed'); raise SystemExit(1)",
+            ]
+        ),
+    )
+    assert rc == 2
+    assert result["status"] == "unavailable"
+
+
+def test_legacy_config_command_still_runs(tmp_path):
+    config = tmp_path / ".claude"
+    config.mkdir()
+    (config / "test-command").write_text(
+        shlex.join([sys.executable, "-c", "print('configured')"])
+    )
+    rc, result = verify(tmp_path)
+    assert rc == 0
+    assert result["output"] == "configured\n"
+
+
+def test_bug_fix_changes_verification_from_failed_to_passed(tmp_path):
+    source = tmp_path / "example.py"
+    source.write_text("def normalize(text):\n    return text\n")
+    (tmp_path / "test_example.py").write_text(
+        "import unittest\nfrom example import normalize\n"
+        "class TestNormalize(unittest.TestCase):\n"
+        "    def test_trims_whitespace(self):\n"
+        "        self.assertEqual(normalize(' hello '), 'hello')\n"
+    )
+    command = shlex.join([sys.executable, "-B", "-m", "unittest", "-v"])
+    rc, before = verify(tmp_path, command)
+    assert rc == 1
+    assert before["status"] == "failed"
+    assert "AssertionError" in before["output"]
+
+    source.write_text("def normalize(text):\n    return text.strip()\n")
+    rc, after = verify(tmp_path, command)
+    assert rc == 0
+    assert after["status"] == "passed"
+    assert "Ran 1 test" in after["output"]


### PR DESCRIPTION
Run quick verification explicitly and report actual command output with separate passed, failed, unavailable, skipped and known-failure states. Validate Maigo subagent responses via documented SubagentStop inputs and reject incomplete or contradictory reports.
Manual hook callers must use agent_type and last_assistant_message.