### PR TITLE
Orchestrator commit and output conventions

### DIFF
--- a/commands/address-comments.md
+++ b/commands/address-comments.md
@@ -154,7 +154,7 @@ triage 檔全欄位骨架（selected 意見 + work items）與路由判斷表（
 - 每個 work item 開跑前把 triage 檔該項 `Status` 改 `in-progress`，完成改 `done`。
 - 被選 route 的失敗處理、Soyo 擋下、Taki 紅、**2** 次同條卡關才停下找使用者——依 [`skills/failure-handling`](https://github.com/Lee-W/maigo/blob/main/skills/failure-handling/SKILL.md)，address-comments 不另立規則。
 - 某個 work item 卡死（依該 route 規則停下找使用者）→ 該項標 `blocked`，**其餘 work item 照常繼續**，最後在 summary 點出卡住的那項。
-- **Commit 政策覆寫**：多個 work item 共享 working tree——若不 commit，後一個 work item 的 Anon / Soyo 會看到前一個的未 commit 改動，污染 diff、混淆 review 焦點。**因此覆寫 inner route 的「不自動 `git commit`」預設**（`/maigo:quick` 流程步驟 4、`/maigo:go` / `/maigo:team` 的 finale 規則）：每個 work item 完成、🟡 Soyo 過、被選 route 的顯式驗證通過後，orchestrator 依步驟 4 使用者選擇的 commit 格式落地：
+- **Commit 時機**：多個 work item 共享 working tree——若不逐項 commit，後一個 work item 的 Anon / Soyo 會看到前一個的未 commit 改動，污染 diff、混淆 review 焦點。inner route 本來就會在驗證綠後落地 commit（`/maigo:quick` 流程步驟 4、`/maigo:go` / `/maigo:team` 的 finale 規則），這裡只是把**時機釘死在每個 work item 之後**、而不是全部做完才一次 commit：每個 work item 完成、🟡 Soyo 過、被選 route 的顯式驗證通過後，orchestrator 依步驟 4 使用者選擇的 commit 格式落地：
 
   - **各自獨立 commit（預設）**：直接用 inner route 草擬的 commit message 落地。subject 格式照 [`skills/commit-message`](https://github.com/Lee-W/maigo/blob/main/skills/commit-message/SKILL.md) 的偵測決定，**不預設 CC**——target repo 的成文慣例優先於 skill 預設。
   - **fixup! commit（使用者在步驟 4 選擇）**：subject 改為 `fixup! <原 PR 主題>`，讓 `git rebase --autosquash` 接得起來。

--- a/commands/go.md
+++ b/commands/go.md
@@ -42,7 +42,7 @@ git worktree add -b <branch> <path> <remote>/<default-branch>
 [`skills/teammate-flow`](https://github.com/Lee-W/maigo/blob/main/skills/teammate-flow/SKILL.md)
 的 cwd 交辦紀律）。
 
-收尾（🟣 立希全綠、commit 草擬完）時印出這個 worktree 的路徑與 branch，明講
+收尾（🟣 立希全綠、commit 已落地）時印出這個 worktree 的路徑與 branch，明講
 「留在原地，等 PR merge 後可用 `/maigo:repo-audit` 看到清理建議」——**不在這裡
 自動移除**。細節、`.maigo/` 歸屬規則見
 [`skills/git-workflow/references/worktree-automation.md`](https://github.com/Lee-W/maigo/blob/main/skills/git-workflow/references/worktree-automation.md)。

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -39,7 +39,7 @@ orchestrator 直接呼叫 Anon 動手，做完跑 Soyo 輕量 review（9 項 →
    - 不寫 plan.md
 2. **爽世 (Soyo)** — 輕量 review，只跑 9 項中的 4 項。「這裡這樣寫，應該不對。」
 3. **Orchestrator 顯式驗證** — 🟡 爽世 APPROVED 後，依下節執行驗證 CLI，保存 command、cwd、exit code 與 output。修過檔案就重跑，不能沿用修改前的結果。
-4. **Orchestrator** — 驗證 `passed` 後，若還有未 commit 的本次變更，依 [`skills/commit-message`](https://github.com/Lee-W/maigo/blob/main/skills/commit-message/SKILL.md) 草擬一段 commit message 附在 final summary。格式照該 skill 的偵測跑，**不預設 CC**——target repo 的成文慣例優先（例：apache/airflow 明禁 CC 前綴並有 commit-msg hook 擋）。**不自動跑 git commit**。接著依 [`skills/pr-sync-check`](https://github.com/Lee-W/maigo/blob/main/skills/pr-sync-check/SKILL.md) 核對當前 branch 若已開 PR，其 title/description 是否仍符合現在的實際改動；沒有對應 PR 就跳過，不算失敗。
+4. **Orchestrator** — 驗證 `passed` 後，若還有未 commit 的本次變更，依 [`skills/commit-message`](https://github.com/Lee-W/maigo/blob/main/skills/commit-message/SKILL.md) 草擬一段 commit message 附在 final summary。格式照該 skill 的偵測跑，**不預設 CC**——target repo 的成文慣例優先（例：apache/airflow 明禁 CC 前綴並有 commit-msg hook 擋）。驗證綠了就**直接落地 commit**（明列檔案路徑 `git add`、不用 `SKIP=`），回報 hash 與 `--stat`；**push 不代跑**。接著依 [`skills/pr-sync-check`](https://github.com/Lee-W/maigo/blob/main/skills/pr-sync-check/SKILL.md) 核對當前 branch 若已開 PR，其 title/description 是否仍符合現在的實際改動；沒有對應 PR 就跳過，不算失敗。
 
 ### 顯式驗證契約（所有宿主共用）
 

--- a/commands/take-issue.md
+++ b/commands/take-issue.md
@@ -1,5 +1,5 @@
 ---
-description: 把 /maigo:triage-issue 判定 READY 的 GitHub issue 接進實作——orchestrator 前置抓料，整理成需求敘述後交給標準 teammate-flow（樂奈探索、燈寫 plan、愛音實作、爽世 review、立希驗證），收尾草擬帶 issue 參照的 commit，不自動 push / 開 PR。
+description: 把 /maigo:triage-issue 判定 READY 的 GitHub issue 接進實作——orchestrator 前置抓料，整理成需求敘述後交給標準 teammate-flow（樂奈探索、燈寫 plan、愛音實作、爽世 review、立希驗證），收尾落地帶 issue 參照的 commit，不自動 push / 開 PR。
 allowed-tools: Bash(gh issue view:*), Read
 ---
 
@@ -35,7 +35,7 @@ git worktree add -b <branch> <path> <remote>/<default-branch>
 [`skills/teammate-flow`](https://github.com/Lee-W/maigo/blob/main/skills/teammate-flow/SKILL.md)
 的 cwd 交辦紀律）。
 
-收尾（🟣 立希全綠、commit 草擬完）時印出這個 worktree 的路徑與 branch，明講
+收尾（🟣 立希全綠、commit 已落地）時印出這個 worktree 的路徑與 branch，明講
 「留在原地，等 PR merge 後可用 `/maigo:repo-audit` 看到清理建議」——**不在這裡
 自動移除**。細節、`.maigo/` 歸屬規則見
 [`skills/git-workflow/references/worktree-automation.md`](https://github.com/Lee-W/maigo/blob/main/skills/git-workflow/references/worktree-automation.md)。
@@ -71,8 +71,8 @@ body + comments 整理成需求敘述：acceptance criteria 從 body 與 maintai
 
 🟣 立希全綠後，依 [`skills/git-workflow`](https://github.com/Lee-W/maigo/blob/main/skills/git-workflow/SKILL.md) /
 [`skills/commit-message`](https://github.com/Lee-W/maigo/blob/main/skills/commit-message/SKILL.md)
-草擬 commit（body 帶 issue 參照，如 `Fixes #<n>` 或 repo 既有慣例）——**不自動 commit、不
-push、不開 PR**。完成後提示可接 [`/maigo:describe-pr`](https://github.com/Lee-W/maigo/blob/main/commands/describe-pr.md) 產 PR title/description。
+草擬 commit 訊息（body 帶 issue 參照，如 `Fixes #<n>` 或 repo 既有慣例）並**直接落地**——
+**不 push、不開 PR**。完成後提示可接 [`/maigo:describe-pr`](https://github.com/Lee-W/maigo/blob/main/commands/describe-pr.md) 產 PR title/description。
 
 ### 4. Work Board 回寫
 
@@ -96,6 +96,6 @@ push、不開 PR**。完成後提示可接 [`/maigo:describe-pr`](https://github
 - **對話**：對話本體（旁白節點以外）的互動節奏與用詞，依
   [`skills/orchestrator-voice`](https://github.com/Lee-W/maigo/blob/main/skills/orchestrator-voice/SKILL.md)。
 - **步驟 1 orchestrator 親自跑、不開新 agent**；步驟 2 依 teammate-flow 的 model-dispatch 結果啟動角色，有 subagents 時委派，沒有時依序在主線執行。
-- **不硬做、不寫 GitHub、不自動 commit**：issue 不是 READY 就建議 `/maigo:triage-issue`；commit 只草擬文字，push / 開 PR 交使用者或 `/maigo:describe-pr`。
+- **不硬做、不寫 GitHub**：issue 不是 READY 就建議 `/maigo:triage-issue`；commit 驗證綠了就落地，push / 開 PR 交使用者或 `/maigo:describe-pr`。
 
 → 跟 `/maigo:triage-issue` / `/maigo:go` 的差異、場景對照：[Commands reference](https://github.com/Lee-W/maigo/blob/main/docs/reference/commands.md)

--- a/docs/commands/go.md
+++ b/docs/commands/go.md
@@ -11,7 +11,7 @@ flowchart TD
     SoyoVerdict -- APPROVED --> Taki[立希 Taki<br/>test / lint / type]
     Taki --> TakiVerdict{全綠?}
     TakiVerdict -- FAIL --> Anon
-    TakiVerdict -- PASS --> Commit[Orchestrator<br/>草擬 commit msg]
+    TakiVerdict -- PASS --> Commit[Orchestrator<br/>落地 commit]
     Commit --> Done([完成: summary])
 
     classDef raana fill:#6EEB83,stroke:#333,color:#000

--- a/docs/commands/quick.md
+++ b/docs/commands/quick.md
@@ -12,7 +12,7 @@ flowchart TD
     SoyoVerdict -- APPROVED --> Verification[Orchestrator<br/>verify_task.py]
     Verification --> HookVerdict{status?}
     HookVerdict -- failed --> Anon
-    HookVerdict -- passed --> Commit[Orchestrator<br/>草擬 commit msg]
+    HookVerdict -- passed --> Commit[Orchestrator<br/>落地 commit]
     HookVerdict -- unavailable / skipped / known_failures --> Unverified([回報未通過驗證與原因])
     Commit --> Done([完成])
 

--- a/docs/commands/team.md
+++ b/docs/commands/team.md
@@ -17,7 +17,7 @@ flowchart TD
     Fork --> Taki
     Soyo --> Join{合流: 爽世 x 立希}
     Taki --> Join
-    Join -- APPROVED + PASS --> Commit[Orchestrator<br/>草擬 commit msg]
+    Join -- APPROVED + PASS --> Commit[Orchestrator<br/>落地 commit]
     Commit --> Done([完成: summary])
     Join -- APPROVED + FAIL --> AnonFixTest[Anon 修 test]
     Join -- BLOCKED + PASS --> AnonFixMust[Anon 修 must-fix]

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -320,7 +320,7 @@ plan，須引用 issue 編號與 acceptance criteria → 🎀 愛音實作 → �
 |------|-----|--------|
 | 1 | Orchestrator | `gh issue view` 抓 body/comments，萃取需求敘述；不是 READY 形狀就建議先 triage |
 | 2-6 | teammate-flow | 依 [`skills/teammate-flow`](../skills/teammate-flow.md) 標準五段 |
-| 7 | Orchestrator | 草擬帶 issue 參照的 commit，不自動 push / 開 PR |
+| 7 | Orchestrator | 落地帶 issue 參照的 commit，不自動 push / 開 PR |
 
 → Source: [`commands/take-issue.md`](../commands/take-issue.md)
 

--- a/skills/commit-message/SKILL.md
+++ b/skills/commit-message/SKILL.md
@@ -119,6 +119,6 @@ When the caller **presents the commit message to the user** as a deliverable (ra
 
 - The PR description / motivation / test plan — that is [`github-title-description`](https://github.com/Lee-W/maigo/blob/main/skills/github-title-description/SKILL.md).
 - Choosing what to commit (`git add` strategy, hunk staging) — caller's job.
-- Running `git commit` — this skill only drafts text.
+- Running `git commit` — this skill only drafts text. Who runs the commit (the orchestrator, once verification is green) and who runs the push (the user, always) is [`git-workflow`](https://github.com/Lee-W/maigo/blob/main/skills/git-workflow/SKILL.md)'s "Pushing and opening a PR" section.
 - Conventional Commits scope taxonomy — if the repo uses CC, the caller decides the scope from the diff; this skill only mirrors the detected style.
 - Multi-commit history shaping (squash decisions, rebase plans) — separate concern.

--- a/skills/copyable-deliverable/SKILL.md
+++ b/skills/copyable-deliverable/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: copyable-deliverable
-description: This skill should be used whenever a maigo command produces a deliverable destined to be pasted elsewhere (a PR/issue comment, a reply draft, a commit message, a gh command draft). It mandates wrapping that content in a single fenced code block so the user gets raw, one-click-copyable markdown instead of a rendered-only version.
+description: This skill should be used whenever a maigo command produces a deliverable destined to be pasted elsewhere (a PR/issue comment, a reply draft, a commit message, a gh command draft). It mandates wrapping that content in a single fenced code block so the user gets raw, one-click-copyable markdown instead of a rendered-only version, and keeps the content itself paste-friendly (no markdown tables, no hard-wrapped prose).
 ---
 
 <!-- mkdocs-include-start -->
@@ -59,6 +59,22 @@ fenced code block 內容不受影響（本來就一行一項 / 逐字保留）�
 
 理由同上：hard-wrap 的段落，使用者每次改字都要重排、diff 也雜；一段一行才好
 複製、好編輯、diff 乾淨。
+
+## 不用表格，改成條列
+
+Deliverable 內**不要用 markdown 表格**——欄位式的內容改寫成條列，一項一行
+（`- **<欄位>**：<值>`），或拆成小節。
+
+理由：deliverable 的宿命是被貼走、被改。表格在純文字編輯器裡欄寬對不齊，補一個
+欄位要重排整列，改一個字 diff 就整列全變；條列改一項只動一行。而且貼上的目的地
+不一定 render markdown——commit message、終端機、純文字 issue tracker 收到的就是
+一堆 `|`。
+
+**唯一例外**：deliverable 要逐字引用的既有內容本來就是表格（例如貼一段原文的比較
+表），照原樣保留，不要為了本規則改寫別人的文字。
+
+適用範圍同上面的 When to apply——對話裡的狀態表、review checklist、queue 表不受
+影響，那些本來就不是 deliverable。
 
 ## What this skill does NOT cover
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -196,7 +196,8 @@ before calling `gh pr create`. After committing and pushing a branch, default to
 stopping there: report the branch/compare URL and ask if a PR should be opened.
 
 **Outward git/GitHub operations are the user's to run, not just PR creation.**
-- Default to drafting (commit message, PR/issue title+body) and stop — never auto-run `git commit` / `git push` / `gh issue create` unless explicitly asked this turn.
+- **`git commit` is authorized; pushing is not.** Once verification is green, commit directly on the branch (never `SKIP=`, never `git add -A`) and report the hash and `--stat` — don't stop at "here's the command, paste it yourself".
+- Everything outward stays drafted-and-stopped — never auto-run `git push` / `--force-with-lease` / `gh pr create` / `gh issue create` unless the user explicitly asks this turn.
 - A "Recommended" pick inside a batch `AskUserQuestion` is not authorization to open an issue — show the draft, wait for "post this".
 - Fixing an already-pushed branch: commit/amend locally and stop; mention `--force-with-lease` but neither run it nor frame it as the recommended next step. Case studies: `references/outward-ops-authority.md`.
 

--- a/skills/git-workflow/references/outward-ops-authority.md
+++ b/skills/git-workflow/references/outward-ops-authority.md
@@ -2,28 +2,32 @@
 
 Loaded on demand by `skills/git-workflow/SKILL.md`'s "Pushing and opening a
 PR" section — **case studies for why outward/irreversible git and GitHub
-operations (commit, push, force-push, opening an issue/PR) stay the user's
-to run**, not the orchestrator's default action.
+operations (push, force-push, opening an issue/PR) stay the user's to run**,
+not the orchestrator's default action. `git commit` is deliberately *not* in
+that set — see item 1 below.
 
 ---
 
-## The user drives outward git ops; the orchestrator only drafts
+## The user drives outward git ops; the orchestrator commits but never pushes
 
 A peer-level maintainer commonly commits, `--amend`s, `fixup!`s, and
 `force-push`es **between** conversation turns, and opens PRs themselves —
 branch tip and PR state can change several times across one session without
 the orchestrator having run any of those commands.
 
-**Why:** outward / irreversible git actions (commit, push, force-push,
-opening a PR) are the kind of thing this user wants to keep in their own
-hands, not delegate to the orchestrator.
+**Why:** outward / irreversible git actions (push, force-push, opening a
+PR) are the kind of thing this user wants to keep in their own hands, not
+delegate to the orchestrator. A local commit is none of those things — it
+stays on the branch, is trivially amendable, and reaches nobody.
 
 **How to apply:**
 
-1. At wrap-up, only **draft** the commit message and PR title+body (in a
-   copyable fenced block) with the commands the user would run themselves.
-   Don't auto-run `git commit` / `git push` / `gh pr create` /
-   `--force-with-lease`.
+1. **Committing is authorized; pushing is not.** Once the change is
+   verified green, run `git commit` on the branch yourself — don't stop at
+   "here's the `git add` line and the message, paste it yourself". Draft the
+   PR/issue title+body in a copyable fenced block with the commands the user
+   would run themselves, and don't auto-run `git push` / `gh pr create` /
+   `gh issue create` / `--force-with-lease`.
    **After a commit is made, report what changed and its state (committed,
    not pushed) — don't add "push this" as an action item.** He tracks which
    branch/worktree he's on and pushes himself; spelling it out as a pending

--- a/skills/pr-sync-check/SKILL.md
+++ b/skills/pr-sync-check/SKILL.md
@@ -12,7 +12,7 @@ description: This skill should be used after a change is complete — at the wra
 
 ## Why this skill exists
 
-改動收尾時，現有流程只草擬 commit message（[`skills/commit-message`](https://github.com/Lee-W/maigo/blob/main/skills/commit-message/SKILL.md)），完全沒有回頭核對「這個 branch 如果已經開著一個 PR，它的 title/description 是否還符合現在的實際改動」。PR 的 title/description 常在多輪 review、追加 commit 之後跟原始描述脫鉤——reviewer 讀到的第一印象已經過期，但沒有任何收尾步驟會發現這件事。這個 skill 補上那個核對步驟，需要時草擬更新，但**絕不代跑 `gh pr edit`**——編輯既有 PR description 是使用者自己的動作，不是「開 PR」那個授權範圍的延伸（見下方「絕不自動編輯」）。
+改動收尾時，現有流程落地 commit（訊息依 [`skills/commit-message`](https://github.com/Lee-W/maigo/blob/main/skills/commit-message/SKILL.md)），完全沒有回頭核對「這個 branch 如果已經開著一個 PR，它的 title/description 是否還符合現在的實際改動」。PR 的 title/description 常在多輪 review、追加 commit 之後跟原始描述脫鉤——reviewer 讀到的第一印象已經過期，但沒有任何收尾步驟會發現這件事。這個 skill 補上那個核對步驟，需要時草擬更新，但**絕不代跑 `gh pr edit`**——編輯既有 PR description 是使用者自己的動作，不是「開 PR」那個授權範圍的延伸（見下方「絕不自動編輯」）。
 
 ## 何時套用
 

--- a/skills/teammate-flow/SKILL.md
+++ b/skills/teammate-flow/SKILL.md
@@ -120,7 +120,7 @@ Orchestrator 對使用者說話時戴上旁白的臉——開場、收場、卡�
   交辦時把已知的新檔清單直接列進 prompt（不必精確，撈漏了對方還會自己 `git status` 補），並明說
   「新增檔不會出現在 `git diff HEAD` 裡」。同理適用於 🟣 立希的驗證交辦。
 
-### Commit message draft
+### Commit message draft + 落地
 
 Taki 全綠（或 `/maigo:team` 合流 APPROVED + PASS）後，若還有未 commit 的本次變更，
 依 [`skills/commit-message`](https://github.com/Lee-W/maigo/blob/main/skills/commit-message/SKILL.md) 從 diff 草擬一段 commit message 附在 final summary。
@@ -131,7 +131,9 @@ maigo 自己的 repo 有 `[tool.commitizen]` 所以是 CC，但這些 command �
 **target repo 的成文慣例優先於 skill 預設**（例：apache/airflow 明禁 CC 前綴，且有
 `check-no-conventional-commit-message` 這個 commit-msg hook 會直接拒收）。
 
-**不自動跑 git commit**——只給文字，使用者自決定要 `git commit -F -` / amend / 改寫。
+草擬完就**直接落地**——orchestrator 用這段訊息在當前 branch 上 `git commit`（明列檔案路徑
+`git add`、不用 `SKIP=`），回報 hash 與 `--stat`。**push 不代跑**，那是使用者的動作。
+使用者要改 wording / amend / 拆合，自己接手即可。
 
 若使用者或後續步驟確實要跑 git 操作（stage / amend / 診斷 diff 大小），
 依 [`skills/git-workflow`](https://github.com/Lee-W/maigo/blob/main/skills/git-workflow/SKILL.md)


### PR DESCRIPTION
- copyable-deliverable 新增「不用表格，改成條列」規則：deliverable 內的欄位式
  內容改寫成一項一行的條列或小節，理由是表格貼進純文字編輯器欄寬會跑掉、
  補欄位要重排整列、改一個字 diff 整列全變。
- 保留唯一例外：deliverable 要逐字引用的既有表格照原樣保留。
- frontmatter description 同步擴寫，涵蓋「內容本身要好貼」這一面。